### PR TITLE
ci: lock versions on minor instead of patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/FuelLabs/data-systems"
 version = "0.0.1"
 
 [workspace.dependencies]
-anyhow = "1.0.86"
-clap = { version = "4.5.4", features = ["derive"] }
-futures = "0.3.30"
-tokio = { version = "1.38.0", features = ["full"] }
+anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
+futures = "0.3"
+tokio = { version = "1.38", features = ["full"] }
 
 [profile.release]
 opt-level = 3

--- a/crates/nats-stream/Cargo.toml
+++ b/crates/nats-stream/Cargo.toml
@@ -11,12 +11,12 @@ description = "Fuel library to handle data streams using Nats"
 
 [dependencies]
 anyhow = { workspace = true }
-async-nats = "0.34.0"
-async-stream = "0.3.5"
+async-nats = "0.34"
+async-stream = "0.3"
 clap = { workspace = true }
-fuel-core-client = "0.22.3"
+fuel-core-client = "0.22"
 fuel-core-client-ext = "0.1"
-fuel-core-types = "0.22.3"
-fuels = "0.54.0"
+fuel-core-types = "0.22"
+fuels = "0.54"
 futures = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
⭐  Closes #10 

The idea here is lock all dependencies in minor instead of patch to avoid an extra step when getting security updates.