### PR TITLE
feat(data-stream): bootstrap the stream from Fuel node's storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,6 +2363,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-nats",
+ "bytes",
  "clap 4.5.7",
  "fuel-core",
  "fuel-core-bin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,15 +1334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-logs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
-dependencies = [
- "sct 0.6.1",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,16 +2053,17 @@ dependencies = [
 
 [[package]]
 name = "eventsource-client"
-version = "0.10.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9146112ee3ce031aa5aebe3e049e10b1d353b9c7630cc6be488c2c62cc5d9c42"
+checksum = "4c80c6714d1a380314fcb11a22eeff022e1e1c9642f0bb54e15dc9cb29f37b29"
 dependencies = [
  "futures",
  "hyper",
- "hyper-rustls 0.22.1",
+ "hyper-rustls",
  "hyper-timeout",
  "log",
  "pin-project",
+ "rand",
  "tokio",
 ]
 
@@ -2154,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
-version = "0.52.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3effa050e7e838d1eff68ca49f2d97558c4f90d13b2ac439253dfa3267c022"
+checksum = "7239ac2ecda5c5cf0bbfb407e7ab59142593cd4625da2d3d7100e7ace8d3e49c"
 dependencies = [
  "bitflags 2.5.0",
  "fuel-types",
@@ -2166,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3758da5cdecc39733b6ccd4960602a5b778dd968685f791299959f2767bbe4be"
+checksum = "07f4d4ee593aa6e2f8286f774561cc9e53679cd209e82d341b0d4f291e99de11"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -2181,6 +2173,7 @@ dependencies = [
  "fuel-core-consensus-module",
  "fuel-core-database",
  "fuel-core-executor",
+ "fuel-core-gas-price-service",
  "fuel-core-importer",
  "fuel-core-metrics",
  "fuel-core-p2p",
@@ -2218,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658c20a1aad29a4dd0a8b443f25f3cb1027cfdef2032e7e0832e7a82a36d1801"
+checksum = "57ae7da0c40b4910c80da94e13f0458007d5be36e3488f8a8709920bfbf08090"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c94ef1b699c840063968db8c6ed0e2c4f8459148cf1c2653fafad867591a36"
+checksum = "35aa4d007c0076b4148ec3c130a67a36fe779e00c37d46112963919c6542cefe"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2265,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671ea8ab1631ffae3f00313c4f1ef169fd0409f6ef5a90532291ce515b88b242"
+checksum = "098a08cc6ea21ebfff0183eb6a645ccfe4d104132b065fd1e74c6161df1364fb"
 dependencies = [
  "anyhow",
  "cynic",
@@ -2276,7 +2269,7 @@ dependencies = [
  "fuel-core-types",
  "futures",
  "hex",
- "hyper-rustls 0.24.2",
+ "hyper-rustls",
  "itertools 0.12.1",
  "reqwest",
  "schemafy_lib",
@@ -2289,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf46dab62dfc542b18bca6f632ad8b0867d05fb19150507f66ccf6f9c41b12d"
+checksum = "2e189a773f52b70341beb16110d1855ce6da9bb4e66f31d7f9d178239aab1f53"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2302,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c0ad3d73cbb1dc9a5c15c232ffc9442ce7ac7e6047d89f346eb9087fef5d68"
+checksum = "a7c0243d2424b32be0bbaac385ae965a4de2fd26f7d7fc347f016935a96d0d40"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2314,9 +2307,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016f18d6386a542b06206ebbb1593a00a90515cf37df10f03aa202adbf1cc92f"
+checksum = "5a16672cdd8cb24083f1b21eb489720b4006d28e108374ccb11eb5d8ba751ec9"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2328,10 +2321,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuel-core-importer"
-version = "0.28.0"
+name = "fuel-core-gas-price-service"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283bc6d4ee195af9780573c1d6a0494f7bc396adf4cc504b5f3130cacea1f444"
+checksum = "e03613cab3e0815e219e1b326a61872d60b0bd2201698c505667ef3a904cb2e1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "fuel-core-services",
+ "fuel-core-types",
+ "futures",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "fuel-core-importer"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35d032bb0ae833bfd5a732857cf848b02540057ee65e3873e12e89211c5c5d79"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2345,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c57acd2e55b0243510cd24c123b039b847eaf74da1852ff758bbafec1743a"
+checksum = "7bca8a133862bed5108af0b27ffdf8a9e0a77e43f2d972fa4a4652c988aa5d90"
 dependencies = [
  "axum",
  "once_cell",
@@ -2378,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb65f5f46005fe914b8d1a8e43e12cc6332430eed856beca098c0a3a5e2209c"
+checksum = "a2328944099941b6ff21dcd7429527a47f269520b50680f077d2e32bca131ee4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2410,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b33fb412a25993ae33137251cbd6dad6fc71e8f7489e009b3ab82c244323d3c3"
+checksum = "010d65baa30f1ad2b4acb4a2763e90ac576e1af4ca851dcb69fb4e177d4ba62c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2427,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822507d802eee1806b6bbece222f0563b1e732898ca46669da7eca36156b3bc2"
+checksum = "5c6c0e4830f01c9c50490bbca532dc30556977fd9af0a57abf4a0206d73ae871"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2443,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f65f0d2d646dc81028488bed954c17ae97c41c1b8707bd9a46f2a47598e94e"
+checksum = "e05cce2f7a55df9412c605e552ef8c094c0520385ce25cbdca29e92d7682e98a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2467,9 +2475,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862791e22d79dc2ce76b27fd57e44d827ae7f0f4dfd7c56fc1fdf7a9bc0286af"
+checksum = "09a656af1acc0cfd660c9a6c9f95daed5da4e2b151eb81ee3dcbd565a112e3e2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2482,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d384d6fbb284aa2b2b76c384261015d9cdb47ca94b898d671f9e2836fc53ec8"
+checksum = "bfc2a6d67ad7fe17a7a8485516585b932642f85fda4c4e47ba67aa974bd87a6c"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2504,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcff2739f418bed4f165a04b6eab37c8b4f8b70efbfc3db286e2cecebe1d5566"
+checksum = "0f3d42538cac6682cbcd27973c32a030b7049978ca800d6a298faa91ce89c59b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2521,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c74944f1b6494580f3b53f12b3b7111f8019b90a974faf2b5713ed11f4f4c6f"
+checksum = "32dd3dea1c2a8d743f0f87b47b919d2e29f5cdd0c97359e876e8735bc2178caf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2531,6 +2539,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-types",
+ "num-rational",
  "parking_lot",
  "tokio",
  "tokio-rayon",
@@ -2540,9 +2549,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ecaf471ba500e936abac536af31d9f5ebdcf89d7fa1a348919fa38af55161a5"
+checksum = "546e02dd8d4844ab27bcb559886d187bcba3a01d7025b8b0c92d75c41693f403"
 dependencies = [
  "anyhow",
  "bs58",
@@ -2558,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4517f24af33b1c6bc15477da1ef0a476eeaf5589848c8171a5ae5516bc6a8c"
+checksum = "9fcaae3550c64c627021a5b0898677223c1970b0423f3d960a82e26a5e85f444"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
@@ -2575,9 +2584,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bc0fa3e91ac702fb6a6ac6110ab77bd250a7934c536e11e0a2c4ec5ef975c7"
+checksum = "8893d3b4418d241031f666ef1237cdc66988108398ba96dde10478b357b1c23c"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
@@ -2589,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.52.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60228bcd5439c9bf206cf337d7d02b40efc56140769db52c2c035d43feb832b"
+checksum = "55716f388824a64be7a18bd5f2b06549717dbd9fdad8af02546e889c78b07327"
 dependencies = [
  "coins-bip32",
  "coins-bip39",
@@ -2610,9 +2619,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
-version = "0.52.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f987a055f018d138248d530a0a40354fa173288c3f81db5b3dfb5087562ebdf"
+checksum = "a8324301ea89931f544f63cd5907e414bfd1bfb3013f5b99afa9dda00504b194"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2622,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.52.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c82370a37e83c53d0a06ce580ccfc4e36eb4cf2b23e67a142de4491d8a2d624"
+checksum = "18f0b623f77576fcfa60a624c56ebf310bf7433da6d8fa6407dfb7e95ebeb8c3"
 dependencies = [
  "derive_more",
  "digest 0.10.7",
@@ -2641,15 +2650,15 @@ version = "0.0.1"
 
 [[package]]
 name = "fuel-storage"
-version = "0.52.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51fc51ee30c4e8b447b4579351128466c507687748d3f1ae9740481d8ef5d5c5"
+checksum = "8be80f1cf059ac87c63fa21b5fa3036472bdb4757c3ba5bae16f0256651e37a1"
 
 [[package]]
 name = "fuel-tx"
-version = "0.52.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23baeb39cbc093b66adb951a205f1696bf2403c0bb1a667fb98ddedeb299a8cb"
+checksum = "e6142c7fd2bf2b1686dee63eb06a06fbb41e453ecb74a4a0c9031156669086f5"
 dependencies = [
  "bitflags 2.5.0",
  "derivative",
@@ -2670,9 +2679,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.52.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960797d6245c3a7a1efc1925216901e644d7e698b81f192f2d2645c3cb7723fb"
+checksum = "38056e7a2b4def574a02e5c9859ffc084e17e565525b5e4a93af6249137d9ca0"
 dependencies = [
  "fuel-derive",
  "hex",
@@ -2681,9 +2690,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.52.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1efb9a8664859711066c9f786a84ff96e804940713d6e2cfcb3c88904d969fd"
+checksum = "6f050af48f6028f2edcc5469e9522ce12b5be6d0761c3cfe7175dea9784e9596"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -3249,23 +3258,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
-dependencies = [
- "ct-logs",
- "futures-util",
- "hyper",
- "log",
- "rustls 0.19.1",
- "rustls-native-certs 0.5.0",
- "tokio",
- "tokio-rustls 0.22.0",
- "webpki",
 ]
 
 [[package]]
@@ -4765,6 +4757,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5640,7 +5643,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls 0.24.2",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
@@ -5829,19 +5832,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64 0.13.1",
- "log",
- "ring 0.16.20",
- "sct 0.6.1",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
@@ -5849,7 +5839,7 @@ dependencies = [
  "log",
  "ring 0.17.8",
  "rustls-webpki 0.101.7",
- "sct 0.7.1",
+ "sct",
 ]
 
 [[package]]
@@ -5864,18 +5854,6 @@ dependencies = [
  "rustls-webpki 0.102.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
-dependencies = [
- "openssl-probe",
- "rustls 0.19.1",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -6045,16 +6023,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
-]
 
 [[package]]
 name = "sct"
@@ -6858,17 +6826,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
-dependencies = [
- "rustls 0.19.1",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
@@ -7664,16 +7621,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "ascii"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,7 +354,7 @@ dependencies = [
  "rand",
  "regex",
  "ring 0.17.8",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.2",
  "rustls-webpki 0.102.4",
  "serde",
@@ -980,6 +986,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "combine"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+dependencies = [
+ "ascii",
+ "byteorder",
+ "either",
+ "memchr",
+ "unreachable",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1066,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cookie"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387461abbc748185c3a6e1673d826918b450b87ff22639429c694619a83b6cf6"
+dependencies = [
+ "cookie",
+ "idna 0.3.0",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "counter"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d458e66999348f56fd3ffcfbb7f7951542075ca8359687c703de6500c1ddccd"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1278,6 +1334,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct 0.6.1",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1380,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "cynic"
+version = "2.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1afa0591b1021e427e548a1f0f147fe6168f6c7c7f7006bace77f28856051b8"
+dependencies = [
+ "cynic-proc-macros",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "static_assertions",
+ "thiserror",
+]
+
+[[package]]
+name = "cynic-codegen"
+version = "2.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a1bb05cc554f46079d0fa72abe995a2d32d0737d410a41da75b31e3f7ef768"
+dependencies = [
+ "counter",
+ "darling 0.13.4",
+ "graphql-parser",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cynic-proc-macros"
+version = "2.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa595c4ed7a5374e0e58c5c34f9d93bd6b7d45062790963bd4b4c3c0bf520c4d"
+dependencies = [
+ "cynic-codegen",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1447,20 @@ checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
 dependencies = [
  "darling_core 0.20.9",
  "darling_macro 0.20.9",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1360,6 +1489,17 @@ dependencies = [
  "quote",
  "strsim 0.11.1",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1921,6 +2061,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-client"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9146112ee3ce031aa5aebe3e049e10b1d353b9c7630cc6be488c2c62cc5d9c42"
+dependencies = [
+ "futures",
+ "hyper",
+ "hyper-rustls 0.22.1",
+ "hyper-timeout",
+ "log",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db81c0bdf07b052d1c595b5ee71e20f0286ca3dc88c7ab3f775e08c8e055c34f"
+checksum = "9e3effa050e7e838d1eff68ca49f2d97558c4f90d13b2ac439253dfa3267c022"
 dependencies = [
  "bitflags 2.5.0",
  "fuel-types",
@@ -2011,9 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecef9aa6c04239c408e37613eb542f81cabb3a10a619b9c793312d38eed9e34"
+checksum = "3758da5cdecc39733b6ccd4960602a5b778dd968685f791299959f2767bbe4be"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -2053,6 +2208,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-rayon",
  "tokio-stream",
  "tokio-util",
  "tower-http",
@@ -2062,9 +2218,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92303bae6c08dd0680b3f879c8624163d291b12b50adcc9ce2caaece5657f0d"
+checksum = "658c20a1aad29a4dd0a8b443f25f3cb1027cfdef2032e7e0832e7a82a36d1801"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2090,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16323762c4a5d58b11121580bee9f3a76ac7f655f95d727f957b05a9e35f477f"
+checksum = "d3c94ef1b699c840063968db8c6ed0e2c4f8459148cf1c2653fafad867591a36"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2108,10 +2264,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuel-core-consensus-module"
-version = "0.27.0"
+name = "fuel-core-client"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85320bb1990ea54ad9fcda4c527c2e42651103c2332cb7ff0b51ecaa23b4c07a"
+checksum = "671ea8ab1631ffae3f00313c4f1ef169fd0409f6ef5a90532291ce515b88b242"
+dependencies = [
+ "anyhow",
+ "cynic",
+ "derive_more",
+ "eventsource-client",
+ "fuel-core-types",
+ "futures",
+ "hex",
+ "hyper-rustls 0.24.2",
+ "itertools 0.12.1",
+ "reqwest",
+ "schemafy_lib",
+ "serde",
+ "serde_json",
+ "tai64",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "fuel-core-consensus-module"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf46dab62dfc542b18bca6f632ad8b0867d05fb19150507f66ccf6f9c41b12d"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2122,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540b36b409d36ace39902509d55d0c758f9cfebc1bcbea07d7115b9923196c9"
+checksum = "41c0ad3d73cbb1dc9a5c15c232ffc9442ce7ac7e6047d89f346eb9087fef5d68"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2134,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367ef0966c99cf1104035257023596256d61a3a5b58b8bac4dcb0bdc8e9b2459"
+checksum = "016f18d6386a542b06206ebbb1593a00a90515cf37df10f03aa202adbf1cc92f"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2149,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7c89083930099a8dad11f5602d4bd935ff5db546ba600cbb9325f6b3bd78ac"
+checksum = "283bc6d4ee195af9780573c1d6a0494f7bc396adf4cc504b5f3130cacea1f444"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2165,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a47f442a32f2e5917066bbf9be3d6fd5d85252a131f1b5fc2f2f0ee75008066"
+checksum = "c20c57acd2e55b0243510cd24c123b039b847eaf74da1852ff758bbafec1743a"
 dependencies = [
  "axum",
  "once_cell",
@@ -2186,6 +2366,7 @@ dependencies = [
  "clap 4.5.7",
  "fuel-core",
  "fuel-core-bin",
+ "fuel-core-client",
  "fuel-core-services",
  "fuel-core-types",
  "futures-util",
@@ -2196,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc6a321f2b1df5be84444ee8b12b647313a5b92a2589d06489bb2b00dbdb2e1"
+checksum = "edb65f5f46005fe914b8d1a8e43e12cc6332430eed856beca098c0a3a5e2209c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2228,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6185f492f9ddb65228db0f250b3f6384637ebf76b72fc81b2efb629d887912"
+checksum = "b33fb412a25993ae33137251cbd6dad6fc71e8f7489e009b3ab82c244323d3c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2245,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efad4ce5bc2f4542e3838a4256158fdd7c537d73e359ba589a4ea86e5c8a2ee0"
+checksum = "822507d802eee1806b6bbece222f0563b1e732898ca46669da7eca36156b3bc2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2261,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6f013eef5af27578b55103c7352f2b7bf12edcd6cf8976937e8e1cd1254a88"
+checksum = "02f65f0d2d646dc81028488bed954c17ae97c41c1b8707bd9a46f2a47598e94e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2285,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35200489fdcdafbe5a6a3a39baad4da523e5c004db9a885056be0137ee35098"
+checksum = "862791e22d79dc2ce76b27fd57e44d827ae7f0f4dfd7c56fc1fdf7a9bc0286af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2300,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4e85b634f42fb53193da517b4a2efa8ac73031cdab653029a5b1d3725572d"
+checksum = "0d384d6fbb284aa2b2b76c384261015d9cdb47ca94b898d671f9e2836fc53ec8"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2322,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1b2d0527a1e730652e4dd157e580a0165b8fc4fd830bb241be35b4bcf178919"
+checksum = "dcff2739f418bed4f165a04b6eab37c8b4f8b70efbfc3db286e2cecebe1d5566"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2333,14 +2514,15 @@ dependencies = [
  "futures",
  "rand",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "800ab382b81de3fa62858862acb25410fdba514fae9b3862065524ac25244678"
+checksum = "9c74944f1b6494580f3b53f12b3b7111f8019b90a974faf2b5713ed11f4f4c6f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2348,7 +2530,6 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-types",
- "futures",
  "parking_lot",
  "tokio",
  "tokio-rayon",
@@ -2358,9 +2539,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe21004dd036f4c454666e339bd0fc3b037535bbc5510321db2565087edd4fc"
+checksum = "0ecaf471ba500e936abac536af31d9f5ebdcf89d7fa1a348919fa38af55161a5"
 dependencies = [
  "anyhow",
  "bs58",
@@ -2376,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7136365b6d48f78ea5ce6bbd3c3c79dece5777ec13a9b63ef4f56abeab6017e"
+checksum = "de4517f24af33b1c6bc15477da1ef0a476eeaf5589848c8171a5ae5516bc6a8c"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
@@ -2393,9 +2574,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa28da9cb6bce835891a9af7d187beb80d98d84380da79d4482b4c0433e95415"
+checksum = "37bc0fa3e91ac702fb6a6ac6110ab77bd250a7934c536e11e0a2c4ec5ef975c7"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
@@ -2407,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca73b3409086e772315625304cabd2eeec10e4bd1f8b8a99cc72e0aed755e5c"
+checksum = "a60228bcd5439c9bf206cf337d7d02b40efc56140769db52c2c035d43feb832b"
 dependencies = [
  "coins-bip32",
  "coins-bip39",
@@ -2428,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d6e66d1b68eb916640c12a1c6c40880e11fcf569359b04483d5e18237c5229"
+checksum = "9f987a055f018d138248d530a0a40354fa173288c3f81db5b3dfb5087562ebdf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2440,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4b60ddfa51b64d02a1d71b0cf51488171d313b32ae3fb9f39f64ddd21791b"
+checksum = "3c82370a37e83c53d0a06ce580ccfc4e36eb4cf2b23e67a142de4491d8a2d624"
 dependencies = [
  "derive_more",
  "digest 0.10.7",
@@ -2459,15 +2640,15 @@ version = "0.0.1"
 
 [[package]]
 name = "fuel-storage"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beef5f12c40118e87ef6abf611c6bba5c88754e727fb825120ae7d0872123055"
+checksum = "51fc51ee30c4e8b447b4579351128466c507687748d3f1ae9740481d8ef5d5c5"
 
 [[package]]
 name = "fuel-tx"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc95857e761db34a50967f53af7a74be08130d210bd985c5585f36bd753d346c"
+checksum = "23baeb39cbc093b66adb951a205f1696bf2403c0bb1a667fb98ddedeb299a8cb"
 dependencies = [
  "bitflags 2.5.0",
  "derivative",
@@ -2488,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af9f9d8c9eb3f4e644731c829ee7da5c3cae0886864731089627af25e336cea"
+checksum = "960797d6245c3a7a1efc1925216901e644d7e698b81f192f2d2645c3cb7723fb"
 dependencies = [
  "fuel-derive",
  "hex",
@@ -2499,9 +2680,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71df1a9ede5237febbc7864888f26365814327732ccd11002e9bddac1ce9a4e6"
+checksum = "b1efb9a8664859711066c9f786a84ff96e804940713d6e2cfcb3c88904d969fd"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2761,6 +2942,16 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "graphql-parser"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
+dependencies = [
+ "combine",
+ "thiserror",
 ]
 
 [[package]]
@@ -3061,6 +3252,23 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls 0.19.1",
+ "rustls-native-certs 0.5.0",
+ "tokio",
+ "tokio-rustls 0.22.0",
+ "webpki",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
@@ -3068,9 +3276,24 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
+ "log",
  "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -3219,6 +3442,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "idna"
@@ -5096,12 +5329,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
 name = "psm"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
+dependencies = [
+ "idna 0.3.0",
+ "psl-types",
 ]
 
 [[package]]
@@ -5381,6 +5630,8 @@ checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -5388,7 +5639,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -5577,6 +5828,19 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.1",
+ "log",
+ "ring 0.16.20",
+ "sct 0.6.1",
+ "webpki",
+]
+
+[[package]]
+name = "rustls"
 version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
@@ -5584,7 +5848,7 @@ dependencies = [
  "log",
  "ring 0.17.8",
  "rustls-webpki 0.101.7",
- "sct",
+ "sct 0.7.1",
 ]
 
 [[package]]
@@ -5599,6 +5863,30 @@ dependencies = [
  "rustls-webpki 0.102.4",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls 0.19.1",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -5726,10 +6014,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemafy_core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41781ae092f4fd52c9287efb74456aea0d3b90032d2ecad272bd14dbbcb0511b"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemafy_lib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e953db32579999ca98c451d80801b6f6a7ecba6127196c5387ec0774c528befa"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "schemafy_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
 
 [[package]]
 name = "sct"
@@ -6501,6 +6825,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6519,6 +6853,17 @@ checksum = "7cf33a76e0b1dd03b778f83244137bd59887abf25c0e87bc3e7071105f457693"
 dependencies = [
  "rayon",
  "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.1",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -6891,6 +7236,15 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+dependencies = [
+ "void",
 ]
 
 [[package]]
@@ -7309,6 +7663,16 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,16 @@ anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 futures = "0.3"
 tokio = { version = "1.38", features = ["full"] }
-fuel-core-bin = { version = "0.28", features = [
+fuel-core-bin = { version = "0.30", features = [
     "env",
     "p2p",
     "relayer",
     "rocksdb",
 ] }
-fuel-core = { version = "0.28", features = ["p2p", "relayer", "rocksdb"] }
-fuel-core-client = { version = "0.28" }
-fuel-core-types = { version = "0.28" }
-fuel-core-services = "0.28"
+fuel-core = { version = "0.30", features = ["p2p", "relayer", "rocksdb"] }
+fuel-core-client = { version = "0.30" }
+fuel-core-types = { version = "0.30" }
+fuel-core-services = "0.30"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,16 @@ anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 futures = "0.3"
 tokio = { version = "1.38", features = ["full"] }
-fuel-core-bin = { version = "0.27", features = [
+fuel-core-bin = { version = "0.28", features = [
     "env",
     "p2p",
     "relayer",
     "rocksdb",
 ] }
-fuel-core = { version = "0.27", features = ["p2p", "relayer", "rocksdb"] }
-fuel-core-types = { version = "0.27" }
-fuel-core-services = "0.27"
+fuel-core = { version = "0.28", features = ["p2p", "relayer", "rocksdb"] }
+fuel-core-client = { version = "0.28" }
+fuel-core-types = { version = "0.28" }
+fuel-core-services = "0.28"
 
 [profile.release]
 opt-level = 3

--- a/crates/fuel-core-nats/Cargo.toml
+++ b/crates/fuel-core-nats/Cargo.toml
@@ -12,6 +12,7 @@ description = "Fuel library to handle data streams using Nats"
 [dependencies]
 anyhow = "1.0.86"
 async-nats = "0.35.1"
+bytes = "1.6.0"
 clap = "4.5.4"
 fuel-core = { workspace = true }
 fuel-core-bin = { workspace = true }

--- a/crates/fuel-core-nats/Cargo.toml
+++ b/crates/fuel-core-nats/Cargo.toml
@@ -15,6 +15,7 @@ async-nats = "0.35.1"
 clap = "4.5.4"
 fuel-core = { workspace = true }
 fuel-core-bin = { workspace = true }
+fuel-core-client = { workspace = true }
 fuel-core-services = { workspace = true }
 fuel-core-types = { workspace = true }
 futures-util = "0.3.30"

--- a/crates/fuel-core-nats/nats.conf
+++ b/crates/fuel-core-nats/nats.conf
@@ -1,0 +1,5 @@
+
+jetstream = {
+    max_file_store = 21474836480
+}
+max_payload = 8388608

--- a/crates/fuel-core-nats/src/lib.rs
+++ b/crates/fuel-core-nats/src/lib.rs
@@ -1,12 +1,23 @@
-use anyhow::{
-    bail,
-    Context,
-};
+use anyhow::Context;
+
 use futures_util::stream::TryStreamExt;
-use tracing::info;
+use tracing::{
+    info,
+    warn,
+};
 
 use fuel_core_types::{
-    fuel_tx::field::Inputs,
+    blockchain::block::Block,
+    fuel_tx::{
+        field::Inputs,
+        Receipt,
+        Transaction,
+        UniqueIdentifier,
+    },
+    fuel_types::{
+        AssetId,
+        ChainId,
+    },
     services::{
         block_importer::ImportResult,
         executor::TransactionExecutionResult,
@@ -25,10 +36,13 @@ const NUM_TOPICS: usize = 3;
 ///   owners.{height}.{owner_id}                                     e.g. owners.*.0xab..cd
 ///   assets.{height}.{asset_id}                                     e.g. assets.*.0xab..cd
 pub async fn nats_publisher(
+    database: &fuel_core::combined_database::CombinedDatabase,
     mut subscription: tokio::sync::broadcast::Receiver<
         std::sync::Arc<dyn std::ops::Deref<Target = ImportResult> + Send + Sync>,
     >,
     nats_url: String,
+    chain_id: &ChainId,
+    base_asset_id: &AssetId,
 ) -> anyhow::Result<()> {
     // Connect to the NATS server
     let client = async_nats::connect(&nats_url)
@@ -56,15 +70,17 @@ pub async fn nats_publisher(
                 // owners.{height}.{owner_id}
                 "owners.*.*".to_string(),
                 // assets.{height}.{asset_id}
-                "assets.*.*.".to_string(),
+                "assets.*.*".to_string(),
             ],
             storage: async_nats::jetstream::stream::StorageType::File,
             ..Default::default()
         })
         .await?;
 
+    info!("NATS Publisher started chain_id={chain_id} base_asset_id={base_asset_id}");
+
     // Check the last block height in the stream
-    let last_block_height = {
+    let stream_height = {
         let config = async_nats::jetstream::consumer::pull::Config {
             deliver_policy: async_nats::jetstream::consumer::DeliverPolicy::Last,
             filter_subject: "blocks.*".to_string(),
@@ -82,142 +98,190 @@ pub async fn nats_publisher(
         }
     };
 
-    info!("NATS Publisher started");
+    // Fill in the stream if neccessary
+    if let Some(chain_height) = database.on_chain().latest_height()? {
+        let chain_height: u32 = chain_height.into();
+        if chain_height > stream_height + 1 {
+            warn!("NATS Publisher: missing blocks: stream block height={stream_height}, chain block height={chain_height}");
+        }
 
+        for height in stream_height + 1..=chain_height {
+            let block: Block = database
+                .on_chain()
+                .get_sealed_block_by_height(&height.into())?
+                .unwrap_or_else(|| panic!("NATS Publisher: no block at height {height}"))
+                .entity;
+
+            use fuel_core_types::services::txpool::TransactionStatus;
+            let mut receipts_: Vec<Receipt> = vec![];
+            for t in block.transactions().iter() {
+                let status: Option<TransactionStatus> =
+                    database.off_chain().get_tx_status(&t.id(chain_id))?;
+                match status {
+                    Some(TransactionStatus::Failed { mut receipts, .. }) => {
+                        receipts_.append(&mut receipts);
+                    }
+                    Some(TransactionStatus::Success { mut receipts, .. }) => {
+                        receipts_.append(&mut receipts);
+                    }
+                    Some(TransactionStatus::Submitted { .. }) => (),
+                    Some(TransactionStatus::SqueezedOut { .. }) => (),
+                    // TODO: check that we'd get the same result from the block importer subscription
+                    None => (),
+                }
+            }
+
+            let height: u32 = **block.header().height();
+
+            info!(
+                "NATS Publisher: publishing block {height} / {chain_height} with {} receipts",
+                receipts_.len()
+            );
+
+            publish_block(&jetstream, base_asset_id, &block, &receipts_).await?;
+        }
+    }
+
+    // Continue publishing blocks from the block importer subscription
     while let Ok(result) = subscription.recv().await {
-        let result = &**result;
-        let height = u32::from(result.sealed_block.entity.header().consensus().height);
-        if height != last_block_height + 1 {
-            bail!("NATS Publisher: missing blocks: stream block height={last_block_height}, chain block height={height}");
-        }
-        let block = &result.sealed_block.entity;
-
-        // Publish the block.
-        info!("NATS Publisher: Block#{height}");
-        let payload = serde_json::to_string_pretty(block)?;
-        jetstream
-            .publish(format!("blocks.{height}"), payload.into())
-            .await?;
-
-        use fuel_core_types::fuel_tx::Transaction;
-        for (index, tx) in block.transactions().iter().enumerate() {
-            if let Transaction::Script(s) = tx {
-                for i in s.inputs() {
-                    if let Some(owner_id) = i.input_owner() {
-                        let payload = serde_json::to_string_pretty(tx)?;
-                        jetstream
-                            .publish(
-                                format!("owners.{height}.{owner_id}"),
-                                payload.into(),
-                            )
-                            .await?;
-                    }
-                    use fuel_core_types::fuel_tx::AssetId;
-                    // TODO: from chain config?
-                    let base_asset_id = AssetId::zeroed();
-                    if let Some(asset_id) = i.asset_id(&base_asset_id) {
-                        let payload = serde_json::to_string_pretty(tx)?;
-                        jetstream
-                            .publish(
-                                format!("assets.{height}.{asset_id}"),
-                                payload.into(),
-                            )
-                            .await?;
-                    }
-                }
-            };
-
-            let tx_kind = match tx {
-                Transaction::Create(_) => "create",
-                Transaction::Mint(_) => "mint",
-                Transaction::Script(_) => "script",
-                Transaction::Upload(_) => "upload",
-                Transaction::Upgrade(_) => "upgrade",
-            };
-
-            // Publish the transaction.
-            info!("NATS Publisher: Transaction#{height}.{index}.{tx_kind}");
-            let payload = serde_json::to_string_pretty(tx)?;
-            jetstream
-                .publish(
-                    format!("transactions.{height}.{index}.{tx_kind}"),
-                    payload.into(),
-                )
-                .await?;
-        }
-
+        let mut receipts_: Vec<Receipt> = vec![];
         for t in result.tx_status.iter() {
-            let receipts = match &t.result {
-                TransactionExecutionResult::Success { receipts, .. } => receipts,
-                TransactionExecutionResult::Failed { receipts, .. } => receipts,
+            let mut receipts = match &t.result {
+                TransactionExecutionResult::Success { receipts, .. } => receipts.clone(),
+                TransactionExecutionResult::Failed { receipts, .. } => receipts.clone(),
             };
+            receipts_.append(&mut receipts);
+        }
+        let result = &**result;
+        publish_block(
+            &jetstream,
+            base_asset_id,
+            &result.sealed_block.entity,
+            &receipts_,
+        )
+        .await?;
+    }
 
-            use fuel_core_types::fuel_tx::Receipt;
-            for r in receipts.iter() {
-                let receipt_kind = match r {
-                    Receipt::Call { .. } => "call",
-                    Receipt::Return { .. } => "return",
-                    Receipt::ReturnData { .. } => "return_data",
-                    Receipt::Panic { .. } => "panic",
-                    Receipt::Revert { .. } => "revert",
-                    Receipt::Log { .. } => "log",
-                    Receipt::LogData { .. } => "log_data",
-                    Receipt::Transfer { .. } => "transfer",
-                    Receipt::TransferOut { .. } => "transfer_out",
-                    Receipt::ScriptResult { .. } => "script_result",
-                    Receipt::MessageOut { .. } => "message_out",
-                    Receipt::Mint { .. } => "mint",
-                    Receipt::Burn { .. } => "burn",
-                };
+    Ok(())
+}
 
-                let contract_id = r.contract_id().map(|x| x.to_string()).unwrap_or(
-                    "0000000000000000000000000000000000000000000000000000000000000000"
-                        .to_string(),
-                );
+/// Publish the Block, its Transactions, and the given Receipts into NATS.
+async fn publish_block(
+    jetstream: &async_nats::jetstream::Context,
+    base_asset_id: &AssetId,
+    block: &Block<Transaction>,
+    receipts: &[Receipt],
+) -> anyhow::Result<()> {
+    let height = u32::from(block.header().consensus().height);
 
-                // Publish the receipt.
-                info!("NATS Publisher: Receipt#{height}.{contract_id}.{receipt_kind}");
-                let payload = serde_json::to_string_pretty(r)?;
-                let subject = format!("receipts.{height}.{contract_id}.{receipt_kind}");
-                jetstream.publish(subject, payload.into()).await?;
+    // Publish the block.
+    info!("NATS Publisher: Block#{height}");
+    let payload = serde_json::to_string_pretty(block)?;
+    jetstream
+        .publish(format!("blocks.{height}"), payload.into())
+        .await?;
 
-                // Publish LogData topics, if any.
-                if let Receipt::LogData {
-                    data: Some(data), ..
-                } = r
-                {
-                    info!("NATS Publisher: Log Data Length: {}", data.len());
-                    // 0x0000000012345678
-                    let header = vec![0, 0, 0, 0, 18, 52, 86, 120];
-                    if data.starts_with(&header) {
-                        let data = &data[header.len()..];
-                        let mut topics = vec![];
-                        for i in 0..NUM_TOPICS {
-                            let topic_bytes: Vec<u8> = data[32 * i..32 * (i + 1)]
-                                .iter()
-                                .cloned()
-                                .take_while(|x| *x > 0)
-                                .collect();
-                            let topic =
-                                String::from_utf8_lossy(&topic_bytes).into_owned();
-                            if !topic.is_empty() {
-                                topics.push(topic);
-                            }
-                        }
-                        let topics = topics.join(".");
-                        // TODO: JSON payload to match other topics? {"data": payload}
-                        let payload = data[NUM_TOPICS * 32..].to_owned();
+    for (index, tx) in block.transactions().iter().enumerate() {
+        if let Transaction::Script(s) = tx {
+            for i in s.inputs() {
+                // Publish transaction to owners
+                if let Some(owner_id) = i.input_owner() {
+                    let payload = serde_json::to_string_pretty(tx)?;
+                    jetstream
+                        .publish(format!("owners.{height}.{owner_id}"), payload.into())
+                        .await?;
+                }
+                // Publish transaction to assets
+                if let Some(asset_id) = i.asset_id(base_asset_id) {
+                    let payload = serde_json::to_string_pretty(tx)?;
+                    jetstream
+                        .publish(format!("assets.{height}.{asset_id}"), payload.into())
+                        .await?;
+                }
+            }
+        }
 
-                        // Publish
-                        info!("NATS Publisher: Receipt#{height}.{contract_id}.{topics}");
-                        jetstream
-                            .publish(
-                                format!("receipts.{height}.{contract_id}.{topics}"),
-                                payload.into(),
-                            )
-                            .await?;
+        let tx_kind = match tx {
+            Transaction::Create(_) => "create",
+            Transaction::Mint(_) => "mint",
+            Transaction::Script(_) => "script",
+            Transaction::Upload(_) => "upload",
+            Transaction::Upgrade(_) => "upgrade",
+        };
+
+        // Publish the transaction.
+        info!("NATS Publisher: Transaction#{height}.{index}.{tx_kind}");
+        let payload = serde_json::to_string_pretty(tx)?;
+        jetstream
+            .publish(
+                format!("transactions.{height}.{index}.{tx_kind}"),
+                payload.into(),
+            )
+            .await?;
+    }
+
+    for r in receipts.iter() {
+        let receipt_kind = match r {
+            Receipt::Call { .. } => "call",
+            Receipt::Return { .. } => "return",
+            Receipt::ReturnData { .. } => "return_data",
+            Receipt::Panic { .. } => "panic",
+            Receipt::Revert { .. } => "revert",
+            Receipt::Log { .. } => "log",
+            Receipt::LogData { .. } => "log_data",
+            Receipt::Transfer { .. } => "transfer",
+            Receipt::TransferOut { .. } => "transfer_out",
+            Receipt::ScriptResult { .. } => "script_result",
+            Receipt::MessageOut { .. } => "message_out",
+            Receipt::Mint { .. } => "mint",
+            Receipt::Burn { .. } => "burn",
+        };
+
+        let contract_id = r.contract_id().map(|x| x.to_string()).unwrap_or(
+            "0000000000000000000000000000000000000000000000000000000000000000"
+                .to_string(),
+        );
+
+        // Publish the receipt.
+        info!("NATS Publisher: Receipt#{height}.{contract_id}.{receipt_kind}");
+        let payload = serde_json::to_string_pretty(r)?;
+        let subject = format!("receipts.{height}.{contract_id}.{receipt_kind}");
+        jetstream.publish(subject, payload.into()).await?;
+
+        // Publish LogData topics, if any.
+        if let Receipt::LogData {
+            data: Some(data), ..
+        } = r
+        {
+            info!("NATS Publisher: Log Data Length: {}", data.len());
+            // 0x0000000012345678
+            let header = vec![0, 0, 0, 0, 18, 52, 86, 120];
+            if data.starts_with(&header) {
+                let data = &data[header.len()..];
+                let mut topics = vec![];
+                for i in 0..NUM_TOPICS {
+                    let topic_bytes: Vec<u8> = data[32 * i..32 * (i + 1)]
+                        .iter()
+                        .cloned()
+                        .take_while(|x| *x > 0)
+                        .collect();
+                    let topic = String::from_utf8_lossy(&topic_bytes).into_owned();
+                    if !topic.is_empty() {
+                        topics.push(topic);
                     }
                 }
+                let topics = topics.join(".");
+                // TODO: JSON payload to match other topics? {"data": payload}
+                let payload = data[NUM_TOPICS * 32..].to_owned();
+
+                // Publish receipt topics
+                info!("NATS Publisher: Receipt#{height}.{contract_id}.{topics}");
+                jetstream
+                    .publish(
+                        format!("receipts.{height}.{contract_id}.{topics}"),
+                        payload.into(),
+                    )
+                    .await?;
             }
         }
     }

--- a/crates/fuel-core-nats/src/lib.rs
+++ b/crates/fuel-core-nats/src/lib.rs
@@ -1,11 +1,17 @@
 use anyhow::Context;
 
 use futures_util::stream::TryStreamExt;
+use std::{
+    ops::Deref,
+    sync::Arc,
+};
+use tokio::sync::broadcast::Receiver;
 use tracing::{
     info,
     warn,
 };
 
+use fuel_core::combined_database::CombinedDatabase;
 use fuel_core_types::{
     blockchain::block::Block,
     fuel_tx::{
@@ -26,265 +32,318 @@ use fuel_core_types::{
 
 const NUM_TOPICS: usize = 3;
 
-/// Connect to a NATS server and publish messages
-///   receipts.{height}.{contract_id}.{kind}                         e.g. receipts.9000.*.return
-///   receipts.{height}.{contract_id}.{topic_1}                      e.g. receipts.*.my_custom_topic
-///   receipts.{height}.{contract_id}.{topic_1}.{topic_2}            e.g. receipts.*.counter.inrc
-///   receipts.{height}.{contract_id}.{topic_1}.{topic_2}.{topic_3}
-///   transactions.{height}.{index}.{kind}                           e.g. transactions.1.1.mint
-///   blocks.{height}                                                e.g. blocks.1
-///   owners.{height}.{owner_id}                                     e.g. owners.*.0xab..cd
-///   assets.{height}.{asset_id}                                     e.g. assets.*.0xab..cd
-pub async fn nats_publisher(
-    database: &fuel_core::combined_database::CombinedDatabase,
-    mut subscription: tokio::sync::broadcast::Receiver<
-        std::sync::Arc<dyn std::ops::Deref<Target = ImportResult> + Send + Sync>,
-    >,
-    nats_url: String,
-    chain_id: &ChainId,
-    base_asset_id: &AssetId,
-) -> anyhow::Result<()> {
-    // Connect to the NATS server
-    let client = async_nats::connect(&nats_url)
-        .await
-        .context(format!("Connecting to {nats_url}"))?;
-    // Create a JetStream context
-    let jetstream = async_nats::jetstream::new(client);
-    // Create a JetStream stream (if it doesn't exist)
-    let _stream = jetstream
-        .get_or_create_stream(async_nats::jetstream::stream::Config {
-            name: "fuel".to_string(),
-            subjects: vec![
-                // blocks.{height}
-                "blocks.*".to_string(),
-                // receipts.{height}.{contract_id}.{kind}
-                // or
-                // receipts.{height}.{contract_id}.{topic_1}
-                "receipts.*.*.*".to_string(),
-                // receipts.{height}.{contract_id}.{topic_1}.{topic_2}
-                "receipts.*.*.*.*".to_string(),
-                // receipts.{height}.{contract_id}.{topic_1}.{topic_2}.{topic_3}
-                "receipts.*.*.*.*.*".to_string(),
-                // transactions.{height}.{index}.{kind}
-                "transactions.*.*.*".to_string(),
-                // owners.{height}.{owner_id}
-                "owners.*.*".to_string(),
-                // assets.{height}.{asset_id}
-                "assets.*.*".to_string(),
-            ],
-            storage: async_nats::jetstream::stream::StorageType::File,
-            ..Default::default()
+pub struct Publisher {
+    jetstream: async_nats::jetstream::Context,
+    chain_id: ChainId,
+    base_asset_id: AssetId,
+    max_payload_size: usize,
+    fuel_database: CombinedDatabase,
+    block_subscription: Receiver<Arc<dyn Deref<Target = ImportResult> + Send + Sync>>,
+}
+
+impl Publisher {
+    pub async fn new(
+        nats_url: &str,
+        chain_id: ChainId,
+        base_asset_id: AssetId,
+        fuel_database: CombinedDatabase,
+        block_subscription: Receiver<Arc<dyn Deref<Target = ImportResult> + Send + Sync>>,
+    ) -> anyhow::Result<Self> {
+        // Connect to the NATS server
+        let client = async_nats::connect(nats_url)
+            .await
+            .context(format!("Connecting to {nats_url}"))?;
+        let max_payload_size = client.server_info().max_payload;
+        info!("NATS Publisher: max_payload_size={max_payload_size}");
+        // Create a JetStream context
+        let jetstream = async_nats::jetstream::new(client);
+        // Create a JetStream stream (if it doesn't exist)
+        let _stream = jetstream
+            .get_or_create_stream(async_nats::jetstream::stream::Config {
+                name: "fuel".to_string(),
+                subjects: vec![
+                    // blocks.{height}
+                    "blocks.*".to_string(),
+                    // receipts.{height}.{contract_id}.{kind}
+                    // or
+                    // receipts.{height}.{contract_id}.{topic_1}
+                    "receipts.*.*.*".to_string(),
+                    // receipts.{height}.{contract_id}.{topic_1}.{topic_2}
+                    "receipts.*.*.*.*".to_string(),
+                    // receipts.{height}.{contract_id}.{topic_1}.{topic_2}.{topic_3}
+                    "receipts.*.*.*.*.*".to_string(),
+                    // transactions.{height}.{index}.{kind}
+                    "transactions.*.*.*".to_string(),
+                    // owners.{height}.{owner_id}
+                    "owners.*.*".to_string(),
+                    // assets.{height}.{asset_id}
+                    "assets.*.*".to_string(),
+                ],
+                storage: async_nats::jetstream::stream::StorageType::File,
+                ..Default::default()
+            })
+            .await?;
+        Ok(Publisher {
+            max_payload_size,
+            chain_id,
+            base_asset_id,
+            jetstream,
+            fuel_database,
+            block_subscription,
         })
-        .await?;
+    }
 
-    info!("NATS Publisher started chain_id={chain_id} base_asset_id={base_asset_id}");
+    /// Connect to a NATS server and publish messages
+    ///   receipts.{height}.{contract_id}.{kind}                         e.g. receipts.9000.*.return
+    ///   receipts.{height}.{contract_id}.{topic_1}                      e.g. receipts.*.my_custom_topic
+    ///   receipts.{height}.{contract_id}.{topic_1}.{topic_2}            e.g. receipts.*.counter.inrc
+    ///   receipts.{height}.{contract_id}.{topic_1}.{topic_2}.{topic_3}
+    ///   transactions.{height}.{index}.{kind}                           e.g. transactions.1.1.mint
+    ///   blocks.{height}                                                e.g. blocks.1
+    ///   owners.{height}.{owner_id}                                     e.g. owners.*.0xab..cd
+    ///   assets.{height}.{asset_id}                                     e.g. assets.*.0xab..cd
+    pub async fn run(mut self) -> anyhow::Result<()> {
+        info!(
+            "NATS Publisher chain_id={} base_asset_id={} started",
+            self.chain_id, self.base_asset_id
+        );
 
-    // Check the last block height in the stream
-    let stream_height = {
-        let config = async_nats::jetstream::consumer::pull::Config {
-            deliver_policy: async_nats::jetstream::consumer::DeliverPolicy::Last,
-            filter_subject: "blocks.*".to_string(),
-            ..Default::default()
+        // Check the last block height in the stream
+        let stream_height = {
+            let config = async_nats::jetstream::consumer::pull::Config {
+                deliver_policy: async_nats::jetstream::consumer::DeliverPolicy::Last,
+                filter_subject: "blocks.*".to_string(),
+                ..Default::default()
+            };
+            let consumer = self
+                .jetstream
+                .create_consumer_on_stream(config, "fuel")
+                .await?;
+            let mut batch = consumer.fetch().max_messages(1).messages().await?;
+
+            if let Ok(Some(message)) = batch.try_next().await {
+                let block_height: u32 =
+                    message.subject.strip_prefix("blocks.").unwrap().parse()?;
+                block_height
+            } else {
+                0
+            }
         };
-        let consumer = jetstream.create_consumer_on_stream(config, "fuel").await?;
-        let mut batch = consumer.fetch().max_messages(1).messages().await?;
 
-        if let Ok(Some(message)) = batch.try_next().await {
-            let block_height: u32 =
-                message.subject.strip_prefix("blocks.").unwrap().parse()?;
-            block_height
-        } else {
-            0
-        }
-    };
-
-    // Fill in the stream if neccessary
-    if let Some(chain_height) = database.on_chain().latest_height()? {
-        let chain_height: u32 = chain_height.into();
-        if chain_height > stream_height + 1 {
-            warn!("NATS Publisher: missing blocks: stream block height={stream_height}, chain block height={chain_height}");
-        }
-
-        for height in stream_height + 1..=chain_height {
-            let block: Block = database
-                .on_chain()
-                .get_sealed_block_by_height(&height.into())?
-                .unwrap_or_else(|| panic!("NATS Publisher: no block at height {height}"))
-                .entity;
-
-            use fuel_core_types::services::txpool::TransactionStatus;
-            let mut receipts_: Vec<Receipt> = vec![];
-            for t in block.transactions().iter() {
-                let status: Option<TransactionStatus> =
-                    database.off_chain().get_tx_status(&t.id(chain_id))?;
-                match status {
-                    Some(TransactionStatus::Failed { mut receipts, .. }) => {
-                        receipts_.append(&mut receipts);
-                    }
-                    Some(TransactionStatus::Success { mut receipts, .. }) => {
-                        receipts_.append(&mut receipts);
-                    }
-                    Some(TransactionStatus::Submitted { .. }) => (),
-                    Some(TransactionStatus::SqueezedOut { .. }) => (),
-                    // TODO: check that we'd get the same result from the block importer subscription
-                    None => (),
-                }
+        // Fast-forward the stream using the local Fuel node database
+        if let Some(chain_height) = self.fuel_database.on_chain().latest_height()? {
+            let chain_height: u32 = chain_height.into();
+            if chain_height > stream_height + 1 {
+                warn!("NATS Publisher: missing blocks: stream block height={stream_height}, chain block height={chain_height}");
             }
 
-            let height: u32 = **block.header().height();
+            for height in stream_height + 1..=chain_height {
+                let block: Block = self
+                    .fuel_database
+                    .on_chain()
+                    .get_sealed_block_by_height(&height.into())?
+                    .unwrap_or_else(|| {
+                        panic!("NATS Publisher: no block at height {height}")
+                    })
+                    .entity;
 
-            info!(
+                use fuel_core_types::services::txpool::TransactionStatus;
+                let mut receipts_: Vec<Receipt> = vec![];
+                let chain_id = self.chain_id;
+                for t in block.transactions().iter() {
+                    let status: Option<TransactionStatus> = self
+                        .fuel_database
+                        .off_chain()
+                        .get_tx_status(&t.id(&chain_id))?;
+                    match status {
+                        Some(TransactionStatus::Failed { mut receipts, .. }) => {
+                            receipts_.append(&mut receipts);
+                        }
+                        Some(TransactionStatus::Success { mut receipts, .. }) => {
+                            receipts_.append(&mut receipts);
+                        }
+                        Some(TransactionStatus::Submitted { .. }) => (),
+                        Some(TransactionStatus::SqueezedOut { .. }) => (),
+                        // TODO: check that we'd get the same result from the block importer subscription
+                        None => (),
+                    }
+                }
+
+                let height: u32 = **block.header().height();
+
+                info!(
                 "NATS Publisher: publishing block {height} / {chain_height} with {} receipts",
                 receipts_.len()
             );
 
-            publish_block(&jetstream, base_asset_id, &block, &receipts_).await?;
-        }
-    }
-
-    // Continue publishing blocks from the block importer subscription
-    while let Ok(result) = subscription.recv().await {
-        let mut receipts_: Vec<Receipt> = vec![];
-        for t in result.tx_status.iter() {
-            let mut receipts = match &t.result {
-                TransactionExecutionResult::Success { receipts, .. } => receipts.clone(),
-                TransactionExecutionResult::Failed { receipts, .. } => receipts.clone(),
-            };
-            receipts_.append(&mut receipts);
-        }
-        let result = &**result;
-        publish_block(
-            &jetstream,
-            base_asset_id,
-            &result.sealed_block.entity,
-            &receipts_,
-        )
-        .await?;
-    }
-
-    Ok(())
-}
-
-/// Publish the Block, its Transactions, and the given Receipts into NATS.
-async fn publish_block(
-    jetstream: &async_nats::jetstream::Context,
-    base_asset_id: &AssetId,
-    block: &Block<Transaction>,
-    receipts: &[Receipt],
-) -> anyhow::Result<()> {
-    let height = u32::from(block.header().consensus().height);
-
-    // Publish the block.
-    info!("NATS Publisher: Block#{height}");
-    let payload = serde_json::to_string_pretty(block)?;
-    jetstream
-        .publish(format!("blocks.{height}"), payload.into())
-        .await?;
-
-    for (index, tx) in block.transactions().iter().enumerate() {
-        if let Transaction::Script(s) = tx {
-            for i in s.inputs() {
-                // Publish transaction to owners
-                if let Some(owner_id) = i.input_owner() {
-                    let payload = serde_json::to_string_pretty(tx)?;
-                    jetstream
-                        .publish(format!("owners.{height}.{owner_id}"), payload.into())
-                        .await?;
-                }
-                // Publish transaction to assets
-                if let Some(asset_id) = i.asset_id(base_asset_id) {
-                    let payload = serde_json::to_string_pretty(tx)?;
-                    jetstream
-                        .publish(format!("assets.{height}.{asset_id}"), payload.into())
-                        .await?;
-                }
+                self.publish_block(&block, &receipts_).await?;
             }
         }
 
-        let tx_kind = match tx {
-            Transaction::Create(_) => "create",
-            Transaction::Mint(_) => "mint",
-            Transaction::Script(_) => "script",
-            Transaction::Upload(_) => "upload",
-            Transaction::Upgrade(_) => "upgrade",
-        };
+        // Continue publishing blocks from the block importer subscription
+        while let Ok(result) = self.block_subscription.recv().await {
+            let mut receipts_: Vec<Receipt> = vec![];
+            for t in result.tx_status.iter() {
+                let mut receipts = match &t.result {
+                    TransactionExecutionResult::Success { receipts, .. } => {
+                        receipts.clone()
+                    }
+                    TransactionExecutionResult::Failed { receipts, .. } => {
+                        receipts.clone()
+                    }
+                };
+                receipts_.append(&mut receipts);
+            }
+            let result = &**result;
+            self.publish_block(&result.sealed_block.entity, &receipts_)
+                .await?;
+        }
 
-        // Publish the transaction.
-        info!("NATS Publisher: Transaction#{height}.{index}.{tx_kind}");
-        let payload = serde_json::to_string_pretty(tx)?;
-        jetstream
-            .publish(
+        Ok(())
+    }
+
+    /// A wrapper around JetStream::publish() that also checks that the payload size does not exceed NATS server's max_payload_size.
+    async fn publish(
+        &self,
+        subject: String,
+        payload: bytes::Bytes,
+    ) -> anyhow::Result<()> {
+        // Check message size
+        let payload_size = payload.len();
+        if payload_size > self.max_payload_size {
+            anyhow::bail!(
+                "{subject} payload size={payload_size} exceeds max_payload_size={}",
+                self.max_payload_size
+            )
+        }
+        // Publish
+        let ack_future = self.jetstream.publish(subject, payload).await?;
+        // Wait for an ACK
+        ack_future.await?;
+        Ok(())
+    }
+
+    /// Publish the Block, its Transactions, and the given Receipts into NATS.
+    pub async fn publish_block(
+        &self,
+        block: &Block<Transaction>,
+        receipts: &[Receipt],
+    ) -> anyhow::Result<()> {
+        let height = u32::from(block.header().consensus().height);
+
+        // Publish the block.
+        info!("NATS Publisher: Block#{height}");
+        let payload = serde_json::to_string_pretty(block)?;
+        self.publish(format!("blocks.{height}"), payload.into())
+            .await?;
+
+        for (index, tx) in block.transactions().iter().enumerate() {
+            if let Transaction::Script(s) = tx {
+                for i in s.inputs() {
+                    // Publish transaction to owners
+                    if let Some(owner_id) = i.input_owner() {
+                        let payload = serde_json::to_string_pretty(tx)?;
+                        self.publish(
+                            format!("owners.{height}.{owner_id}"),
+                            payload.into(),
+                        )
+                        .await?;
+                    }
+                    // Publish transaction to assets
+                    if let Some(asset_id) = i.asset_id(&self.base_asset_id) {
+                        let payload = serde_json::to_string_pretty(tx)?;
+                        self.publish(
+                            format!("assets.{height}.{asset_id}"),
+                            payload.into(),
+                        )
+                        .await?;
+                    }
+                }
+            }
+
+            let tx_kind = match tx {
+                Transaction::Create(_) => "create",
+                Transaction::Mint(_) => "mint",
+                Transaction::Script(_) => "script",
+                Transaction::Upload(_) => "upload",
+                Transaction::Upgrade(_) => "upgrade",
+            };
+
+            // Publish the transaction.
+            info!("NATS Publisher: Transaction#{height}.{index}.{tx_kind}");
+            let payload = serde_json::to_string_pretty(tx)?;
+            self.publish(
                 format!("transactions.{height}.{index}.{tx_kind}"),
                 payload.into(),
             )
             .await?;
-    }
+        }
 
-    for r in receipts.iter() {
-        let receipt_kind = match r {
-            Receipt::Call { .. } => "call",
-            Receipt::Return { .. } => "return",
-            Receipt::ReturnData { .. } => "return_data",
-            Receipt::Panic { .. } => "panic",
-            Receipt::Revert { .. } => "revert",
-            Receipt::Log { .. } => "log",
-            Receipt::LogData { .. } => "log_data",
-            Receipt::Transfer { .. } => "transfer",
-            Receipt::TransferOut { .. } => "transfer_out",
-            Receipt::ScriptResult { .. } => "script_result",
-            Receipt::MessageOut { .. } => "message_out",
-            Receipt::Mint { .. } => "mint",
-            Receipt::Burn { .. } => "burn",
-        };
+        for r in receipts.iter() {
+            let receipt_kind = match r {
+                Receipt::Call { .. } => "call",
+                Receipt::Return { .. } => "return",
+                Receipt::ReturnData { .. } => "return_data",
+                Receipt::Panic { .. } => "panic",
+                Receipt::Revert { .. } => "revert",
+                Receipt::Log { .. } => "log",
+                Receipt::LogData { .. } => "log_data",
+                Receipt::Transfer { .. } => "transfer",
+                Receipt::TransferOut { .. } => "transfer_out",
+                Receipt::ScriptResult { .. } => "script_result",
+                Receipt::MessageOut { .. } => "message_out",
+                Receipt::Mint { .. } => "mint",
+                Receipt::Burn { .. } => "burn",
+            };
 
-        let contract_id = r.contract_id().map(|x| x.to_string()).unwrap_or(
-            "0000000000000000000000000000000000000000000000000000000000000000"
-                .to_string(),
-        );
+            let contract_id = r.contract_id().map(|x| x.to_string()).unwrap_or(
+                "0000000000000000000000000000000000000000000000000000000000000000"
+                    .to_string(),
+            );
 
-        // Publish the receipt.
-        info!("NATS Publisher: Receipt#{height}.{contract_id}.{receipt_kind}");
-        let payload = serde_json::to_string_pretty(r)?;
-        let subject = format!("receipts.{height}.{contract_id}.{receipt_kind}");
-        jetstream.publish(subject, payload.into()).await?;
+            // Publish the receipt.
+            info!("NATS Publisher: Receipt#{height}.{contract_id}.{receipt_kind}");
+            let payload = serde_json::to_string_pretty(r)?;
+            let subject = format!("receipts.{height}.{contract_id}.{receipt_kind}");
+            self.publish(subject, payload.into()).await?;
 
-        // Publish LogData topics, if any.
-        if let Receipt::LogData {
-            data: Some(data), ..
-        } = r
-        {
-            info!("NATS Publisher: Log Data Length: {}", data.len());
-            // 0x0000000012345678
-            let header = vec![0, 0, 0, 0, 18, 52, 86, 120];
-            if data.starts_with(&header) {
-                let data = &data[header.len()..];
-                let mut topics = vec![];
-                for i in 0..NUM_TOPICS {
-                    let topic_bytes: Vec<u8> = data[32 * i..32 * (i + 1)]
-                        .iter()
-                        .cloned()
-                        .take_while(|x| *x > 0)
-                        .collect();
-                    let topic = String::from_utf8_lossy(&topic_bytes).into_owned();
-                    if !topic.is_empty() {
-                        topics.push(topic);
+            // Publish LogData topics, if any.
+            if let Receipt::LogData {
+                data: Some(data), ..
+            } = r
+            {
+                info!("NATS Publisher: Log Data Length: {}", data.len());
+                // 0x0000000012345678
+                let header = vec![0, 0, 0, 0, 18, 52, 86, 120];
+                if data.starts_with(&header) {
+                    let data = &data[header.len()..];
+                    let mut topics = vec![];
+                    for i in 0..NUM_TOPICS {
+                        let topic_bytes: Vec<u8> = data[32 * i..32 * (i + 1)]
+                            .iter()
+                            .cloned()
+                            .take_while(|x| *x > 0)
+                            .collect();
+                        let topic = String::from_utf8_lossy(&topic_bytes).into_owned();
+                        if !topic.is_empty() {
+                            topics.push(topic);
+                        }
                     }
-                }
-                let topics = topics.join(".");
-                // TODO: JSON payload to match other topics? {"data": payload}
-                let payload = data[NUM_TOPICS * 32..].to_owned();
+                    let topics = topics.join(".");
+                    // TODO: JSON payload to match other topics? {"data": payload}
+                    let payload = data[NUM_TOPICS * 32..].to_owned();
 
-                // Publish receipt topics
-                info!("NATS Publisher: Receipt#{height}.{contract_id}.{topics}");
-                jetstream
-                    .publish(
+                    // Publish receipt topics
+                    info!("NATS Publisher: Receipt#{height}.{contract_id}.{topics}");
+                    self.publish(
                         format!("receipts.{height}.{contract_id}.{topics}"),
                         payload.into(),
                     )
                     .await?;
+                }
             }
         }
-    }
 
-    Ok(())
+        Ok(())
+    }
 }

--- a/crates/fuel-core-nats/src/main.rs
+++ b/crates/fuel-core-nats/src/main.rs
@@ -22,11 +22,21 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
     let service = run::get_service(cli.fuel_core_config)?;
+    let chain_config = service.shared.config.snapshot_reader.chain_config();
+    let chain_id = chain_config.consensus_parameters.chain_id();
+    let base_asset_id = chain_config.consensus_parameters.base_asset_id();
     service.start()?;
 
     let subscription = service.shared.block_importer.block_importer.subscribe();
 
-    fuel_core_nats::nats_publisher(subscription, cli.nats_url).await?;
+    fuel_core_nats::nats_publisher(
+        &service.shared.database,
+        subscription,
+        cli.nats_url,
+        &chain_id,
+        base_asset_id,
+    )
+    .await?;
 
     Ok(())
 }

--- a/crates/fuel-core-nats/src/main.rs
+++ b/crates/fuel-core-nats/src/main.rs
@@ -29,14 +29,15 @@ async fn main() -> anyhow::Result<()> {
 
     let subscription = service.shared.block_importer.block_importer.subscribe();
 
-    fuel_core_nats::nats_publisher(
-        &service.shared.database,
+    let publisher = fuel_core_nats::Publisher::new(
+        &cli.nats_url,
+        chain_id,
+        *base_asset_id,
+        service.shared.database.clone(),
         subscription,
-        cli.nats_url,
-        &chain_id,
-        base_asset_id,
     )
     .await?;
+    publisher.run().await?;
 
     Ok(())
 }


### PR DESCRIPTION
Closes #26 

After `3548979` blocks:

```
nats str ls
╭──────────────────────────────────────────────────────────────────────────────╮
│                                    Streams                                   │
├──────┬─────────────┬─────────────────────┬───────────┬────────┬──────────────┤
│ Name │ Description │ Created             │ Messages  │ Size   │ Last Message │
├──────┼─────────────┼─────────────────────┼───────────┼────────┼──────────────┤
│ fuel │             │ 2024-06-12 16:59:04 │ 7,111,105 │ 12 GiB │ 3m9s         │
╰──────┴─────────────┴─────────────────────┴───────────┴────────┴──────────────╯
```

```
nats sub "receipts.>" --last
11:29:28 Subscribing to JetStream Stream holding messages with subject receipts.> starting with the last message received
[#1] Received JetStream message: stream: fuel seq 7104149 / subject: receipts.3548979.0000000000000000000000000000000000000000000000000000000000000000.script_result / time: 2024-06-14T11:14:56+02:00
{
  "ScriptResult": {
    "result": "Success",
    "gas_used": 0
  }
}
```