### PR TITLE
build(repo): introduce Docker image for `fuel-core-nats`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,22 @@ setup: check-commands
 # ------------------------------------------------------------
 #  Development
 # ------------------------------------------------------------
+# Starts all services
+start:	COMMANDS=docker
+start:	check-commands
+	docker compose -f docker/docker-compose.yml up
+
+stop:
+	docker compose -f docker/docker-compose.yml down
+
+start.nats:	COMMANDS=docker
+start.nats: check-commands
+	docker run -p 4222:4222 -p 8222:8222 -p 6222:6222 --name fuel-core-nats-server -ti nats:latest --js
+
+stop.nats:
+	docker stop $$(docker ps -q --filter ancestor=nats:latest)
+	docker rm $$(docker ps -a -q --filter ancestor=nats:latest)
+
 # Starts fuel-core-nats service
 start.fuel-core-nats:
 	./scripts/start-fuel-core-nats.sh
@@ -40,13 +56,6 @@ dev-watch:
 
 build: install
 	cargo build --release --target "$(TARGET)" --package "$(PACKAGE)"
-
-start-nats:	CMDS=docker-compose
-start-nats: check-commands
-	docker-compose -f docker/docker-compose.yml up
-
-stop-nats:
-	docker-compose -f docker/docker-compose.yml down
 
 run:
 	cargo run --release

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,6 +2,14 @@ version: '3.9'
 
 services:
   nats:
-    image: nats:2.10.16
-    ports: [4222:4222]
-    command: [--name=fuel-core-nats-server, --js]
+    image: nats:latest
+    ports: [4222:4222, 8222:8222]
+    command: [-m, '8222', --name=fuel-core-nats-server, --js]
+  fuel-core-nats:
+    image: fuel-core-nats:latest
+    depends_on: [nats]
+    env_file: [./../.env]
+    environment: [NATS_URL=nats://nats:4222]
+    build:
+      context: .
+      dockerfile: fuel-core-nats.Dockerfile

--- a/docker/fuel-core-nats.Dockerfile
+++ b/docker/fuel-core-nats.Dockerfile
@@ -1,0 +1,104 @@
+# Stage 1: Build
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+FROM --platform=$BUILDPLATFORM rust:1.75.0 AS chef
+
+ARG TARGETPLATFORM
+RUN cargo install cargo-chef && rustup target add wasm32-unknown-unknown
+WORKDIR /build/
+
+COPY --from=xx / /
+
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    lld \
+    clang \
+    libclang-dev \
+    && xx-apt-get update  \
+    && xx-apt-get install -y libc6-dev g++ binutils \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM chef as planner
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+
+FROM chef as builder
+ARG DEBUG_SYMBOLS=false
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+ENV CARGO_PROFILE_RELEASE_DEBUG=$DEBUG_SYMBOLS
+COPY --from=planner /build/recipe.json recipe.json
+RUN echo $CARGO_PROFILE_RELEASE_DEBUG
+# Build our project dependencies, not our application!
+RUN xx-cargo chef cook --release --no-default-features -p fuel-core-nats --recipe-path recipe.json
+# Up to this point, if our dependency tree stays the same,
+# all layers should be cached.
+COPY . .
+RUN xx-cargo build --release --no-default-features -p fuel-core-nats \
+    && xx-verify ./target/$(xx-cargo --print-target-triple)/release/fuel-core-nats \
+    && mv ./target/$(xx-cargo --print-target-triple)/release/fuel-core-nats ./target/release/fuel-core-nats \
+    && mv ./target/$(xx-cargo --print-target-triple)/release/fuel-core-nats.d ./target/release/fuel-core-nats.d
+
+# Stage 2: Run
+FROM ubuntu:22.04 as run
+
+ARG IP=0.0.0.0
+ARG PORT=4000
+ARG P2P_PORT=30333
+ARG DB_PATH=./mnt/db/
+ARG POA_INSTANT=false
+ARG RELAYER_LOG_PAGE_SIZE=2000
+ARG SERVICE_NAME="NATS Publisher Node"
+ARG SYNC_HEADER_BATCH_SIZE=100
+
+ENV IP=$IP
+ENV PORT=$PORT
+ENV DB_PATH=$DB_PATH
+ENV POA_INSTANT=false
+ENV RELAYER_LOG_PAGE_SIZE=$RELAYER_LOG_PAGE_SIZE
+ENV SERVICE_NAME=$SERVICE_NAME
+ENV SYNC_HEADER_BATCH_SIZE=$SYNC_HEADER_BATCH_SIZE
+
+ENV KEYPAIR=
+ENV RELAYER=
+ENV RELAYER_V2_LISTENING_CONTRACTS=
+ENV RELAYER_DA_DEPLOY_HEIGHT=
+ENV NATS_URL=
+
+WORKDIR /root/
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/fuel-core-nats .
+COPY --from=builder /build/target/release/fuel-core-nats.d .
+
+EXPOSE $PORT
+EXPOSE $P2P_PORT
+
+# https://stackoverflow.com/a/44671685
+# https://stackoverflow.com/a/40454758
+# hadolint ignore=DL3025
+CMD exec ./fuel-core-nats \
+    --ip $IP \
+    --port $PORT \
+    --db-path "${DB_PATH}" \
+    --enable-p2p \
+    --poa-instant $POA_INSTANT \
+    --utxo-validation \
+    --keypair $KEYPAIR \
+    --enable-relayer \
+    --relayer $RELAYER \
+    --relayer-v2-listening-contracts $RELAYER_V2_LISTENING_CONTRACTS \
+    --relayer-da-deploy-height $RELAYER_DA_DEPLOY_HEIGHT \
+    --relayer-log-page-size $RELAYER_LOG_PAGE_SIZE \
+    --service-name "${SERVICE_NAME}" \
+    --sync-header-batch-size $SYNC_HEADER_BATCH_SIZE \
+    --nats-url "${NATS_URL}" \


### PR DESCRIPTION
Alongside the Dockerfile for `fuel-core-nats`, this PR:

- re-purposes docker-compose for starting and stopping all services in this repo
- Adds some Makefile script aliases to manage(start/stop) all services or simply manage each service in isolation.