### PR TITLE
ci(repo): adjust commitlint to enable dependabot

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,6 +1,7 @@
 extends: ['@commitlint/config-conventional']
 
 rules:
+  body-max-line-length: [0, always, Infinity]
   type-enum:
     - 2
     - always

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
             test
           scopes: |
             repo
+            deps
             release
             data-stream
             sdk-rust
@@ -67,16 +68,18 @@ jobs:
 
       - name: Install commitlint
         run: |
+          npm install commitlint@latest
           npm install @commitlint/config-conventional
 
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'
-        run: npx commitlint --last --verbose
+        run: npx commitlint --config ./.commitlintrc.yaml --last --verbose
 
       - name: Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
         run: |
           npx commitlint \
+            --config ./.commitlintrc.yaml \
             --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} \
             --to ${{ github.event.pull_request.head.sha }} \
             --verbose


### PR DESCRIPTION
This will enable Dependabot to commit using it's standard `build(deps):` commit format.