### PR TITLE
ci(release): Add jobs for publishing `fuel-core-nats` crate and binaries

### DIFF
--- a/.github/actions/docker-publish/action.yaml
+++ b/.github/actions/docker-publish/action.yaml
@@ -1,48 +1,48 @@
-name: 'Build & Push Docker'
+name: Build & Push Docker
 
 inputs:
   compose-version:
-    description: 'Docker Dompose version'
+    description: Docker Dompose version
     default: 2.6.0
   registry:
-    description: 'Docker registry service'
+    description: Docker registry service
     default: ghcr.io
   username:
-    description: 'Username for https://ghcr.io'
+    description: Username for https://ghcr.io
     required: true
   password:
-    description: 'Password for https://ghcr.io'
+    description: Password for https://ghcr.io
     required: true
   image:
-    description: 'Image name with provider url'
+    description: Image name with provider url
     required: true
   dockerfile:
-    description: 'Path to the Dockerfile'
+    description: Path to the Dockerfile
     required: true
   context:
-    description: 'Path to the Context'
+    description: Path to the Context
     default: .
     required: true
   build-args:
-    description: 'List of build-time variables'
+    description: List of build-time variables
     required: false
 
 outputs:
   image:
-    description: 'Image url'
-    value: ${{ steps.imageOuput.outputs.imageUrl }}
+    description: Image url
+    value: ${{ steps.imageOutput.outputs.imageUrl }}
   imageid:
-    description: 'Image ID'
+    description: Image ID
     value: ${{ steps.publish.outputs.imageId }}
   digest:
-    description: 'Image digest'
+    description: Image digest
     value: ${{ steps.publish.outputs.digest }}
   metadata:
-    description: 'Build result metadata'
+    description: Build result metadata
     value: ${{ steps.publish.outputs.metadata }}
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - name: Log in to the ghcr.io registry
       uses: docker/login-action@v2
@@ -78,7 +78,7 @@ runs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
-    - id: imageOuput
+    - id: imageOutput
       shell: bash
-      run: |
+      run: |-
         echo "imageUrl=${{ fromJSON(steps.publish.outputs.metadata)['image.name'] }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CLICOLOR: 1
-  RUST_VERSION: 1.78.0
+  RUST_VERSION: 1.79.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -11,7 +11,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CLICOLOR: 1
-  RUST_VERSION: 1.78.0
+  RUST_VERSION: 1.79.0
 
 jobs:
   setup:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,19 +58,107 @@ jobs:
       contents: read
       actions: write
     steps:
-      - uses: actions/checkout@v4.1.6
-      - uses: actions/download-artifact@v4.1.7
+      - name: Checkout Repository
+        uses: actions/checkout@v4.1.6
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4.1.7
         with:
           path: artifacts
           merge-multiple: true
 
-      - name: List artifacts
+      - name: List Artifacts
         run: ls -R artifacts
 
-      - uses: knope-dev/action@v2.1.0
+      - name: Cache Artifacts
+        uses: actions/cache@v3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: artifacts
+          key: ${{ runner.os }}-artifacts-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-artifacts-
 
-      - run: knope release
+      - name: Run Knope Action
+        uses: knope-dev/action@v2.1.0
+        with:
+          github-token: ${{ secrets.REPO_TOKEN }}
+
+      - name: Knope Release
+        run: knope release
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+          github-token: ${{ secrets.REPO_TOKEN }}
+
+  publish-crates:
+    needs: [release]
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: buildjet-4vcpu-ubuntu-2204
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Restore Artifacts Cache
+        uses: actions/cache@v3
+        with:
+          path: artifacts
+          key: ${{ runner.os }}-artifacts-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-artifacts-
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: wasm32-unknown-unknown
+
+      - name: Publish Crate
+        uses: FuelLabs/publish-crates@v1
+        with:
+          publish-delay: 60000
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  publish-docker-image:
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/fuellabs/fuel-core-nats
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{raw}}
+            type=raw,value=sha-{{sha}}-{{date 'YYYYMMDDhhmmss'}}
+          flavor: |
+            latest=${{ github.ref == 'refs/heads/master' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the ghcr.io registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.REPO_TOKEN }}
+
+      - name: Build and push the image to ghcr.io
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          file: docker/fuel-core-nats.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/fuellabs/fuel-core-nats-cache:latest
+          cache-to: type=registry,ref=ghcr.io/fuellabs/fuel-core-nats-cache:latest,mode=max

--- a/.github/workflows/update_deps.yaml
+++ b/.github/workflows/update_deps.yaml
@@ -22,7 +22,7 @@ defaults:
 env:
   # Prevents cargo from complaining about unstable features
   RUSTC_BOOTSTRAP: 1
-  RUST_VERSION: 1.78.0
+  RUST_VERSION: 1.79.0
   PR_TITLE: 'chore(deps): weekly `cargo update`'
   PR_MESSAGE: |
     Automation to keep dependencies in `Cargo.lock` current.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown", "aarch64-unknown-linux-gnu"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.78.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32-unknown-unknown", "aarch64-unknown-linux-gnu"]


### PR DESCRIPTION
References: https://github.com/FuelLabs/data-systems/issues/15

For the `fuel-core-nats` crate, this PR adds jobs for publishing:
- its Docker image
- ~its binaries within the automated Github Release~
- on crates.io

N/B: This is currently failing because we have not set some important credentials. We need: 
- ~`secrets.GITHUB_TOKEN`~ =>  `secrets.REPO_TOKEN`
- `secrets.DOCKER_IO_READ_ONLY_TOKEN`
- ~`secrets.SLACK_WEBHOOK_NOTIFY_BUILD`~

Dev Note: After the workflow test is done, we should revert this commit: https://github.com/FuelLabs/data-systems/commit/a3227c84e0c34e38e64ddb9f704441fbbff89711
