### PR TITLE
fix(data-stream): use u32 for block height to avoid hex outputs in block subjects

### DIFF
--- a/crates/fuel-core-nats/src/lib.rs
+++ b/crates/fuel-core-nats/src/lib.rs
@@ -153,7 +153,7 @@ impl Publisher {
         &self,
         block: &Block<Transaction>,
     ) -> anyhow::Result<()> {
-        let height = block.header().consensus().height;
+        let height: u32 = *block.header().consensus().height;
 
         // Publish the block.
         info!("NATS Publisher: Block#{height}");

--- a/crates/fuel-core-nats/src/nats/subjects.rs
+++ b/crates/fuel-core-nats/src/nats/subjects.rs
@@ -1,4 +1,3 @@
-use fuel_core_types::fuel_types::BlockHeight;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
@@ -31,10 +30,10 @@ impl std::fmt::Display for SubjectName {
 #[derive(Debug)]
 pub enum Subject {
     Blocks {
-        height: BlockHeight,
+        height: u32,
     },
     Transactions {
-        height: BlockHeight,
+        height: u32,
         index: usize,
         kind: String,
     },


### PR DESCRIPTION
Fuel BlockHeight type `to_string()` outputs hexadecimal which is optimized and perfect for their use-case. For our streams, it will be better to store the integer value directly since it will save us a tidbit of compute time when decoding, which will happen more than encoding.

Because of the hexadecimal output, decoding the block height's subject failed as it expected a regular integer, not a hexadecimal. This change fixes this by replacing the `BlockHeight` type with a `u32`.

N/B: This fix also requires re-publishing. So we need to run:`nats str purge 'blocks.*' -f` & `nats str purge 'transactions.*.*.*' -f` right before deploy.