### PR TITLE
refactor(repo): add AsRef trait for api arguments

### DIFF
--- a/crates/core/src/nats/errors.rs
+++ b/crates/core/src/nats/errors.rs
@@ -48,4 +48,7 @@ pub enum NatsError {
 
     #[error("Connection to NATS server at {0} is disconnected")]
     ConnectionDisconnected(String),
+
+    #[error("Missing stream of kind {name}")]
+    MissingStreamOfKind { name: String },
 }

--- a/crates/core/src/nats/mod.rs
+++ b/crates/core/src/nats/mod.rs
@@ -18,9 +18,9 @@ pub struct Nats {
 
 impl Nats {
     pub async fn new(
-        conn_id: &str,
-        nats_url: &str,
-        nats_nkey: &str,
+        conn_id: impl AsRef<str>,
+        nats_url: impl AsRef<str>,
+        nats_nkey: impl AsRef<str>,
     ) -> Result<Self, NatsError> {
         let client = NatsClient::connect(nats_url, conn_id, nats_nkey).await?;
         let streams = Streams::new(&client).await.unwrap();

--- a/crates/core/src/nats/subjects.rs
+++ b/crates/core/src/nats/subjects.rs
@@ -11,13 +11,13 @@ pub enum SubjectName {
 }
 
 impl SubjectName {
-    pub fn with_prefix(&self, prefix: &str) -> String {
-        [prefix, ".", &self.to_string()].concat()
+    pub fn with_prefix(&self, prefix: impl AsRef<str>) -> String {
+        [prefix.as_ref(), ".", &self.to_string()].concat()
     }
 
-    pub fn to_vec(prefix: &str) -> Vec<String> {
+    pub fn to_vec(prefix: impl AsRef<str>) -> Vec<String> {
         SubjectName::iter()
-            .map(|name| name.with_prefix(prefix))
+            .map(|name| name.with_prefix(prefix.as_ref()))
             .collect()
     }
 }
@@ -58,8 +58,8 @@ pub enum Subject {
 }
 
 impl Subject {
-    pub fn with_prefix(&self, prefix: &str) -> String {
-        [prefix, ".", &self.to_string()].concat()
+    pub fn with_prefix(&self, prefix: impl AsRef<str>) -> String {
+        [prefix.as_ref(), ".", &self.to_string()].concat()
     }
 
     #[allow(dead_code)]

--- a/crates/fuel-core-nats/src/lib.rs
+++ b/crates/fuel-core-nats/src/lib.rs
@@ -24,8 +24,8 @@ pub struct Publisher {
 
 impl Publisher {
     pub async fn new(
-        nats_url: &str,
-        nats_nkey: &str,
+        nats_url: impl AsRef<str>,
+        nats_nkey: impl AsRef<str>,
         chain_id: ChainId,
         base_asset_id: AssetId,
         fuel_core_database: CombinedDatabase,
@@ -33,7 +33,8 @@ impl Publisher {
             Arc<dyn Deref<Target = ImportResult> + Send + Sync>,
         >,
     ) -> anyhow::Result<Self> {
-        let nats = nats::connect(nats_url, nats_nkey, None).await?;
+        let nats =
+            nats::connect(nats_url.as_ref(), nats_nkey.as_ref(), None).await?;
 
         Ok(Publisher {
             chain_id,

--- a/crates/fuel-core-nats/src/nats.rs
+++ b/crates/fuel-core-nats/src/nats.rs
@@ -80,10 +80,11 @@ impl NatsConnection {
 }
 
 pub async fn connect(
-    nats_url: &str,
-    nats_nkey: &str,
+    nats_url: impl AsRef<str>,
+    nats_nkey: impl AsRef<str>,
     connection_id: Option<String>,
 ) -> anyhow::Result<NatsConnection> {
+    let nats_url = nats_url.as_ref();
     let connection_id = &connection_id.unwrap_or_default();
     let config = stream::Config {
         name: format!("{connection_id}fuel"),
@@ -94,7 +95,7 @@ pub async fn connect(
 
     let client = async_nats::connect_with_options(
         nats_url,
-        async_nats::ConnectOptions::with_nkey(nats_nkey.to_string()),
+        async_nats::ConnectOptions::with_nkey(nats_nkey.as_ref().to_string()),
     )
     .await
     .context(format!("Connecting to {nats_url}"))?;

--- a/crates/fuel-core-nats/src/nats/subjects.rs
+++ b/crates/fuel-core-nats/src/nats/subjects.rs
@@ -10,8 +10,8 @@ pub enum SubjectName {
 impl SubjectName {
     // TODO: Extract this in a ConnectionAware trait? where there
     // are more connection-related operations
-    pub fn get_string(&self, connection_id: &str) -> String {
-        [connection_id, &self.to_string()].concat()
+    pub fn get_string(&self, connection_id: impl AsRef<str>) -> String {
+        [connection_id.as_ref(), &self.to_string()].concat()
     }
 }
 
@@ -53,8 +53,8 @@ impl std::fmt::Display for Subject {
 }
 
 impl Subject {
-    pub fn get_string(&self, connection_id: &str) -> String {
-        [connection_id, &self.to_string()].concat()
+    pub fn get_string(&self, connection_id: impl AsRef<str>) -> String {
+        [connection_id.as_ref(), &self.to_string()].concat()
     }
 
     #[allow(dead_code)]
@@ -66,7 +66,8 @@ impl Subject {
     }
 }
 
-pub fn get_all_in_connection(connection_id: &str) -> Vec<String> {
+pub fn get_all_in_connection(connection_id: impl AsRef<str>) -> Vec<String> {
+    let connection_id = connection_id.as_ref();
     get_all()
         .iter()
         .map(|name| format!("{connection_id}{name}"))


### PR DESCRIPTION
This small PR adds:

- a more ergonomic interface for input args which can now implement AsRef<str> allowing them to be of types String, &str, Cow<str> etc as well as any other AsRef impl

- removes one unwrap and maps it to a proper error message