### PR TITLE
fix(publisher): publish compact json rather than pretty json

### DIFF
--- a/crates/fuel-core-nats/src/lib.rs
+++ b/crates/fuel-core-nats/src/lib.rs
@@ -158,7 +158,7 @@ impl Publisher {
 
         // Publish the block.
         info!("NATS Publisher: Block#{height}");
-        let payload = serde_json::to_string_pretty(block)?;
+        let payload = serde_json::to_string(block)?;
 
         let block_subject = nats::Subject::Blocks { height };
         self.nats.publish(block_subject, payload.into()).await?;
@@ -173,7 +173,7 @@ impl Publisher {
             };
 
             // Publish the transaction.
-            let payload = serde_json::to_string_pretty(tx)?;
+            let payload = serde_json::to_string(tx)?;
             let transactions_subject = nats::Subject::Transactions {
                 height,
                 index,


### PR DESCRIPTION
Currently, we are publishing our subjects and payloads using pretty json. This quickly added up and caused a large ROM consumption in our NATS cluster. For obvious reasons, pretty json is way heavier compared with it's compact equivalent. This change fixes this by only publishing the blocks and transactions serialized to compact json.