### PR TITLE
refactor(core): keep `fuel-streams` naming consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,10 +2641,32 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "dotenvy",
+ "fuel-streams-core",
  "futures-util",
- "streams-core",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "fuel-streams-core"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "bytes",
+ "dotenvy",
+ "fuel-core",
+ "fuel-core-types",
+ "futures-util",
+ "pretty_assertions",
+ "rand",
+ "serde_json",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -6327,38 +6349,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "streams-core"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "async-nats",
- "async-trait",
- "bytes",
- "dotenvy",
- "fuel-core",
- "fuel-core-types",
- "futures-util",
- "pretty_assertions",
- "rand",
- "serde_json",
- "strum 0.26.3",
- "strum_macros 0.26.4",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "streams-tests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-nats",
  "fuel-streams",
+ "fuel-streams-core",
  "futures",
  "futures-util",
  "pretty_assertions",
- "streams-core",
  "tokio",
 ]
 

--- a/crates/fuel-streams-core/Cargo.toml
+++ b/crates/fuel-streams-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "streams-core"
+name = "fuel-streams-core"
 authors = { workspace = true }
 keywords = { workspace = true }
 edition = { workspace = true }

--- a/crates/fuel-streams/Cargo.toml
+++ b/crates/fuel-streams/Cargo.toml
@@ -11,8 +11,8 @@ version = { workspace = true }
 [dependencies]
 async-trait = { workspace = true }
 dotenvy = { workspace = true }
+fuel-streams-core = { path = "../fuel-streams-core" }
 futures-util = { workspace = true }
-streams-core = { path = "../fuel-streams-core" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 

--- a/crates/fuel-streams/src/client/client_impl.rs
+++ b/crates/fuel-streams/src/client/client_impl.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use async_trait::async_trait;
-use streams_core::prelude::*;
+use fuel_streams_core::prelude::*;
 
 use super::ConnectionResult;
 

--- a/crates/fuel-streams/src/client/types.rs
+++ b/crates/fuel-streams/src/client/types.rs
@@ -1,4 +1,4 @@
-use streams_core::nats::NatsError;
+use fuel_streams_core::nats::NatsError;
 
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub enum ClientStatus {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,11 +20,9 @@ path = "tests/lib.rs"
 anyhow = { workspace = true }
 async-nats = { workspace = true }
 fuel-streams = { path = "../crates/fuel-streams", features = ["test-helpers"] }
+fuel-streams-core = { path = "../crates/fuel-streams-core", features = ["test-helpers"] }
 futures = { workspace = true }
 futures-util = { workspace = true }
-streams-core = { path = "../crates/fuel-streams-core", features = [
-    "test-helpers",
-] }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/tests/tests/client.rs
+++ b/tests/tests/client.rs
@@ -1,8 +1,8 @@
 use async_nats::connection::State;
 use fuel_streams::prelude::*;
+use fuel_streams_core::prelude::*;
 use futures_util::future::try_join_all;
 use pretty_assertions::assert_eq;
-use streams_core::prelude::*;
 
 #[tokio::test]
 async fn fuel_streams_client_connection() -> BoxedResult<()> {

--- a/tests/tests/conn.rs
+++ b/tests/tests/conn.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
+use fuel_streams_core::prelude::*;
 use futures_util::TryStreamExt;
-use streams_core::prelude::*;
 
 #[tokio::test]
 async fn conn_streams_has_same_context_streams() -> BoxedResult<()> {

--- a/tests/tests/streams.rs
+++ b/tests/tests/streams.rs
@@ -1,5 +1,5 @@
+use fuel_streams_core::prelude::*;
 use futures_util::StreamExt;
-use streams_core::prelude::*;
 
 #[tokio::test]
 async fn public_user_cannot_create_streams() {


### PR DESCRIPTION
Quickly getting this conflict out the way for https://github.com/FuelLabs/data-systems/issues/97. `fuel-streams` is the end product of our systems so far, so, it would be better to have that detail in the core crate's namespace. This PR does that update.