### PR TITLE
fix(publisher): temporary solution for nats storage size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,6 +2675,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-nats",
+ "bincode",
  "bytes",
  "clap 4.5.13",
  "dotenvy",

--- a/crates/fuel-streams-publisher/Cargo.toml
+++ b/crates/fuel-streams-publisher/Cargo.toml
@@ -12,6 +12,7 @@ description = "Fuel library for publishing data streams from events that happen 
 [dependencies]
 anyhow = { workspace = true }
 async-nats = { workspace = true }
+bincode = "1.3.3"
 bytes = "1.6.0"
 clap = { workspace = true }
 dotenvy = { workspace = true }

--- a/crates/fuel-streams-publisher/src/lib.rs
+++ b/crates/fuel-streams-publisher/src/lib.rs
@@ -2,7 +2,6 @@ mod nats;
 
 use std::{ops::Deref, sync::Arc};
 
-use async_nats::jetstream::context::Publish;
 use fuel_core::combined_database::CombinedDatabase;
 use fuel_core_types::{
     blockchain::block::Block,

--- a/crates/fuel-streams-publisher/src/nats.rs
+++ b/crates/fuel-streams-publisher/src/nats.rs
@@ -3,7 +3,7 @@ mod subjects;
 use anyhow::Context;
 use async_nats::jetstream::{
     context::{Publish, PublishErrorKind},
-    stream,
+    stream::{self, Compression},
 };
 pub use subjects::*;
 use tracing::info;
@@ -98,6 +98,7 @@ pub async fn connect(
         name: format!("{connection_id}fuel"),
         subjects: subjects::get_all_in_connection(connection_id),
         storage: async_nats::jetstream::stream::StorageType::File,
+        compression: Some(Compression::S2),
         ..Default::default()
     };
 


### PR DESCRIPTION
This solution is temporary because our NATS service is running out of storage in the Cluster again. I conducted some tests by using `bincode` for serialization instead of JSON, and found that it reduced the size by 4 times. Additionally, enabling NATS default compression as an option in the stream also helped with the size reduction.