### PR TITLE
ci(repo): Adjust knope for manual releases

### DIFF
--- a/.changeset/docs_update.md
+++ b/.changeset/docs_update.md
@@ -1,0 +1,7 @@
+---
+fuel-streams: patch
+---
+
+# Documentation Update Release
+
+This is a version bump to create a new release that includes updated documentation. No functional changes have been made to the codebase; this release is solely to publish the latest documentation updates.

--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -61,6 +61,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run knope prepare release
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
           RELEASE_BRANCH: ${{ needs.setup.outputs.branch }}

--- a/knope.toml
+++ b/knope.toml
@@ -99,6 +99,15 @@ template = "v$VERSION"
 variables = { "$VERSION" = "Version" }
 
 # ------------------------------------------------------------
+# Workflow to create a changeset
+# ------------------------------------------------------------
+[[workflows]]
+name = "document-change"
+
+[[workflows.steps]]
+type = "CreateChangeFile"
+
+# ------------------------------------------------------------
 # Workflow to release a new version
 # ------------------------------------------------------------
 [[workflows]]


### PR DESCRIPTION
# Description

The `prepare-release.yml` action throws an error when there's no bump to create a new version. Since we need to bump for a new release to update the documentation in the crates, but we don't have any bump in the three conventional commits, we need to bump manually using changesets (`knope document-change`).