### PR TITLE
feat(publisher): Publish predicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3244,6 +3244,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_prometheus",
+ "sha2 0.10.8",
  "sysinfo",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ pretty_assertions = "1.4.1"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 strum = "0.26"
 strum_macros = "0.26"
 tokio = { version = "1.40", features = ["full"] }

--- a/crates/fuel-streams-core/src/stream/stream_impl.rs
+++ b/crates/fuel-streams-core/src/stream/stream_impl.rs
@@ -142,6 +142,15 @@ impl<S: Streamable> Stream<S> {
         payload: &S,
     ) -> Result<usize, StreamError> {
         let subject_name = &subject.parse();
+        self.publish_raw(subject_name, payload).await
+    }
+
+    /// Publish with subject name with no static guarantees of the subject
+    pub async fn publish_raw(
+        &self,
+        subject_name: &str,
+        payload: &S,
+    ) -> Result<usize, StreamError> {
         let data = payload.encode(subject_name).await;
         let data_size = data.len();
         let result = self.store.create(subject_name, data.into()).await;

--- a/crates/fuel-streams-core/src/transactions/mod.rs
+++ b/crates/fuel-streams-core/src/transactions/mod.rs
@@ -1,6 +1,7 @@
 pub mod subjects;
 pub mod types;
 
+use fuel_core_types::fuel_tx::{field::Outputs, Output};
 pub use subjects::*;
 use types::*;
 
@@ -13,4 +14,41 @@ impl Streamable for Transaction {
         TransactionsSubject::WILDCARD,
         TransactionsByIdSubject::WILDCARD,
     ];
+}
+
+pub trait WithTxInputs {
+    fn inputs(&self) -> &[Input];
+}
+
+pub trait WithTxOutputs {
+    fn outputs(&self) -> &Vec<Output>;
+}
+
+impl WithTxInputs for Transaction {
+    fn inputs(&self) -> &[Input] {
+        match self {
+            Transaction::Mint(_) => &[],
+            Transaction::Script(tx) => tx.inputs(),
+            Transaction::Blob(tx) => tx.inputs(),
+            Transaction::Create(tx) => tx.inputs(),
+            Transaction::Upload(tx) => tx.inputs(),
+            Transaction::Upgrade(tx) => tx.inputs(),
+        }
+    }
+}
+
+impl WithTxOutputs for Transaction {
+    fn outputs(&self) -> &Vec<Output> {
+        match self {
+            Transaction::Mint(_) => {
+                static NO_OUTPUTS: Vec<Output> = Vec::new();
+                &NO_OUTPUTS
+            }
+            Transaction::Script(tx) => tx.outputs(),
+            Transaction::Blob(tx) => tx.outputs(),
+            Transaction::Create(tx) => tx.outputs(),
+            Transaction::Upload(tx) => tx.outputs(),
+            Transaction::Upgrade(tx) => tx.outputs(),
+        }
+    }
 }

--- a/crates/fuel-streams-core/src/types.rs
+++ b/crates/fuel-streams-core/src/types.rs
@@ -12,6 +12,7 @@ pub use crate::{
     logs::types::*,
     nats::types::*,
     transactions::types::*,
+    utxos::types::*,
 };
 
 // ------------------------------------------------------------------------

--- a/crates/fuel-streams-core/src/utxos/subjects.rs
+++ b/crates/fuel-streams-core/src/utxos/subjects.rs
@@ -16,7 +16,7 @@ use super::{types::UtxoType, MessageId};
 /// # use fuel_streams_core::types::*;
 /// # use fuel_streams_macros::subject::*;
 /// let subject = UtxosSubject {
-///     tx_id: Some(Bytes32::from([1u8; 32]).into()),
+///     hash: Some(MessageId::from([1u8; 32])),
 ///     utxo_type: Some(UtxoType::Message),
 /// };
 /// assert_eq!(
@@ -40,11 +40,10 @@ use super::{types::UtxoType, MessageId};
 /// # use fuel_streams_core::types::*;
 /// # use fuel_streams_macros::subject::*;
 /// let wildcard = UtxosSubject::wildcard(
+///     Some(MessageId::from([1u8; 32])),
 ///     None,
-///     Some(Bytes32::from([1u8; 32]).into()),
-///     Some(UtxoType::Message),
 /// );
-/// assert_eq!(wildcard, "utxos.message.0x0101010101010101010101010101010101010101010101010101010101010101");
+/// assert_eq!(wildcard, "utxos.*.0x0101010101010101010101010101010101010101010101010101010101010101");
 /// ```
 ///
 /// Using the builder pattern:
@@ -54,7 +53,7 @@ use super::{types::UtxoType, MessageId};
 /// # use fuel_streams_core::types::*;
 /// # use fuel_streams_macros::subject::*;
 /// let subject = UtxosSubject::new()
-///     .with_tx_id(Some(Bytes32::from([1u8; 32])))
+///     .with_hash(Some(MessageId::from([1u8; 32])))
 ///     .with_utxo_type(Some(UtxoType::Message));
 /// assert_eq!(subject.parse(), "utxos.message.0x0101010101010101010101010101010101010101010101010101010101010101");
 /// ```
@@ -62,7 +61,6 @@ use super::{types::UtxoType, MessageId};
 #[derive(Subject, Debug, Clone, Default)]
 #[subject_wildcard = "utxos.>"]
 #[subject_format = "utxos.{utxo_type}.{hash}"]
-#[allow(clippy::too_many_arguments)]
 pub struct UtxosSubject {
     pub hash: Option<MessageId>,
     pub utxo_type: Option<UtxoType>,

--- a/crates/fuel-streams-publisher/Cargo.toml
+++ b/crates/fuel-streams-publisher/Cargo.toml
@@ -37,6 +37,7 @@ rand = { workspace = true }
 rust_decimal = { version = "1.13" }
 serde = { workspace = true }
 serde_prometheus = { version = "0.2.5" }
+sha2 = { workspace = true }
 sysinfo = { version = "0.29.2" }
 thiserror = "1.0.63"
 tokio = { workspace = true }

--- a/crates/fuel-streams-publisher/src/inputs.rs
+++ b/crates/fuel-streams-publisher/src/inputs.rs
@@ -101,7 +101,7 @@ pub async fn publish(
     chain_id: &ChainId,
     metrics: &Arc<PublisherMetrics>,
     block_producer: &Address,
-    predicate_tag: &Option<Bytes32>,
+    predicate_tag: Option<Bytes32>,
 ) -> anyhow::Result<()> {
     let tx_id = transaction.id(chain_id);
 
@@ -171,7 +171,7 @@ pub async fn publish(
             InputSubject::Contract(by_id_subject, subject, payload) => {
                 publish_with_metrics!(
                     stream.publish_raw(
-                        &build_subject_name(predicate_tag, &subject),
+                        &build_subject_name(&predicate_tag, &subject),
                         &payload
                     ),
                     metrics,
@@ -181,7 +181,7 @@ pub async fn publish(
                 );
                 publish_with_metrics!(
                     stream.publish_raw(
-                        &build_subject_name(predicate_tag, &by_id_subject),
+                        &build_subject_name(&predicate_tag, &by_id_subject),
                         &payload
                     ),
                     metrics,
@@ -193,7 +193,7 @@ pub async fn publish(
             InputSubject::Coin(by_id_subject, subject, payload) => {
                 publish_with_metrics!(
                     stream.publish_raw(
-                        &build_subject_name(predicate_tag, &subject),
+                        &build_subject_name(&predicate_tag, &subject),
                         &payload
                     ),
                     metrics,
@@ -203,7 +203,7 @@ pub async fn publish(
                 );
                 publish_with_metrics!(
                     stream.publish_raw(
-                        &build_subject_name(predicate_tag, &by_id_subject),
+                        &build_subject_name(&predicate_tag, &by_id_subject),
                         &payload
                     ),
                     metrics,
@@ -220,7 +220,7 @@ pub async fn publish(
             ) => {
                 publish_with_metrics!(
                     stream.publish_raw(
-                        &build_subject_name(predicate_tag, &subject),
+                        &build_subject_name(&predicate_tag, &subject),
                         &payload
                     ),
                     metrics,
@@ -231,7 +231,7 @@ pub async fn publish(
                 publish_with_metrics!(
                     stream.publish_raw(
                         &build_subject_name(
-                            predicate_tag,
+                            &predicate_tag,
                             &by_id_sender_subject
                         ),
                         &payload
@@ -244,7 +244,7 @@ pub async fn publish(
                 publish_with_metrics!(
                     stream.publish_raw(
                         &build_subject_name(
-                            predicate_tag,
+                            &predicate_tag,
                             &by_id_recipient_subject
                         ),
                         &payload

--- a/crates/fuel-streams-publisher/src/inputs.rs
+++ b/crates/fuel-streams-publisher/src/inputs.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use fuel_core_types::fuel_tx::{
-    field::Inputs,
     input::{
         coin::{Coin, CoinSpecification},
         message::{Message, MessageSpecification},
@@ -10,30 +9,18 @@ use fuel_core_types::fuel_tx::{
 };
 use fuel_streams_core::{
     inputs::{
-        InputsByIdSubject,
-        InputsCoinSubject,
-        InputsContractSubject,
+        InputsByIdSubject, InputsCoinSubject, InputsContractSubject,
         InputsMessageSubject,
     },
     prelude::*,
+    transactions::WithTxInputs,
     types::{Bytes32, IdentifierKind, Input, Transaction},
     Stream,
 };
 
-use crate::{metrics::PublisherMetrics, publish_with_metrics, FuelCoreLike};
-
-macro_rules! get_inputs {
-    ($transaction:expr, $($variant:ident),+) => {
-        match $transaction {
-            Transaction::Mint(_) => vec![],
-            $(Transaction::$variant(tx) => tx.inputs().to_vec(),)+
-        }
-    };
-}
-
-pub fn inputs_from_transaction(transaction: &Transaction) -> Vec<Input> {
-    get_inputs!(transaction, Script, Blob, Create, Upload, Upgrade)
-}
+use crate::{
+    build_subject_name, metrics::PublisherMetrics, publish_with_metrics,
+};
 
 fn coin_subject<T: CoinSpecification>(
     coin: &Coin<T>,
@@ -109,113 +96,116 @@ enum InputSubject {
 }
 
 pub async fn publish(
-    metrics: &Arc<PublisherMetrics>,
     stream: &Stream<Input>,
-    fuel_core: &dyn FuelCoreLike,
-    transactions: &[Transaction],
+    transaction: &Transaction,
+    chain_id: &ChainId,
+    metrics: &Arc<PublisherMetrics>,
     block_producer: &Address,
+    predicate_tag: &Option<Bytes32>,
 ) -> anyhow::Result<()> {
-    let chain_id = fuel_core.chain_id();
-    let subjects: Vec<InputSubject> = transactions
+    let tx_id = transaction.id(chain_id);
+
+    let subjects = transaction
+        .inputs()
         .iter()
-        .flat_map(|transaction| {
-            let tx_id = transaction.id(fuel_core.chain_id());
-            let inputs = inputs_from_transaction(transaction);
-            inputs
-                .iter()
-                .enumerate()
-                .map(|(index, input)| match input {
-                    Input::Contract(contract) => {
-                        let (by_id, subject) = contract_subject(
-                            contract.contract_id,
-                            tx_id.into(),
-                            index,
-                        );
-                        InputSubject::Contract(by_id, subject, input.to_owned())
-                    }
-                    Input::CoinSigned(coin) => {
-                        let (by_id, subject) =
-                            coin_subject(coin, tx_id.into(), index);
-                        InputSubject::Coin(by_id, subject, input.to_owned())
-                    }
-                    Input::CoinPredicate(coin) => {
-                        let (by_id, subject) =
-                            coin_subject(coin, tx_id.into(), index);
-                        InputSubject::Coin(by_id, subject, input.to_owned())
-                    }
-                    Input::MessageCoinSigned(message) => {
-                        let (by_id_sender, by_id_recipient, subject) =
-                            message_subject(message, tx_id.into(), index);
-                        InputSubject::Message(
-                            by_id_sender,
-                            by_id_recipient,
-                            subject,
-                            input.to_owned(),
-                        )
-                    }
-                    Input::MessageCoinPredicate(message) => {
-                        let (by_id_sender, by_id_recipient, subject) =
-                            message_subject(message, tx_id.into(), index);
-                        InputSubject::Message(
-                            by_id_sender,
-                            by_id_recipient,
-                            subject,
-                            input.to_owned(),
-                        )
-                    }
-                    Input::MessageDataSigned(message) => {
-                        let (by_id_sender, by_id_recipient, subject) =
-                            message_subject(message, tx_id.into(), index);
-                        InputSubject::Message(
-                            by_id_sender,
-                            by_id_recipient,
-                            subject,
-                            input.to_owned(),
-                        )
-                    }
-                    Input::MessageDataPredicate(message) => {
-                        let (by_id_sender, by_id_recipient, subject) =
-                            message_subject(message, tx_id.into(), index);
-                        InputSubject::Message(
-                            by_id_sender,
-                            by_id_recipient,
-                            subject,
-                            input.to_owned(),
-                        )
-                    }
-                })
-                .collect::<Vec<InputSubject>>()
+        .enumerate()
+        .map(|(index, input)| match input {
+            Input::Contract(contract) => {
+                let (by_id, subject) =
+                    contract_subject(contract.contract_id, tx_id.into(), index);
+                InputSubject::Contract(by_id, subject, input.to_owned())
+            }
+            Input::CoinSigned(coin) => {
+                let (by_id, subject) = coin_subject(coin, tx_id.into(), index);
+                InputSubject::Coin(by_id, subject, input.to_owned())
+            }
+            Input::CoinPredicate(coin) => {
+                let (by_id, subject) = coin_subject(coin, tx_id.into(), index);
+                InputSubject::Coin(by_id, subject, input.to_owned())
+            }
+            Input::MessageCoinSigned(message) => {
+                let (by_id_sender, by_id_recipient, subject) =
+                    message_subject(message, tx_id.into(), index);
+                InputSubject::Message(
+                    by_id_sender,
+                    by_id_recipient,
+                    subject,
+                    input.to_owned(),
+                )
+            }
+            Input::MessageCoinPredicate(message) => {
+                let (by_id_sender, by_id_recipient, subject) =
+                    message_subject(message, tx_id.into(), index);
+                InputSubject::Message(
+                    by_id_sender,
+                    by_id_recipient,
+                    subject,
+                    input.to_owned(),
+                )
+            }
+            Input::MessageDataSigned(message) => {
+                let (by_id_sender, by_id_recipient, subject) =
+                    message_subject(message, tx_id.into(), index);
+                InputSubject::Message(
+                    by_id_sender,
+                    by_id_recipient,
+                    subject,
+                    input.to_owned(),
+                )
+            }
+            Input::MessageDataPredicate(message) => {
+                let (by_id_sender, by_id_recipient, subject) =
+                    message_subject(message, tx_id.into(), index);
+                InputSubject::Message(
+                    by_id_sender,
+                    by_id_recipient,
+                    subject,
+                    input.to_owned(),
+                )
+            }
         })
-        .collect();
+        .collect::<Vec<InputSubject>>();
 
     for subject_item in subjects {
         match subject_item {
-            InputSubject::Contract(by_id, subject, payload) => {
+            InputSubject::Contract(by_id_subject, subject, payload) => {
                 publish_with_metrics!(
-                    stream.publish(&subject, &payload),
+                    stream.publish_raw(
+                        &build_subject_name(predicate_tag, &subject),
+                        &payload
+                    ),
                     metrics,
                     chain_id,
                     block_producer,
                     InputsContractSubject::WILDCARD
                 );
                 publish_with_metrics!(
-                    stream.publish(&by_id, &payload),
+                    stream.publish_raw(
+                        &build_subject_name(predicate_tag, &by_id_subject),
+                        &payload
+                    ),
                     metrics,
                     chain_id,
                     block_producer,
                     InputsByIdSubject::WILDCARD
                 );
             }
-            InputSubject::Coin(by_id, subject, payload) => {
+            InputSubject::Coin(by_id_subject, subject, payload) => {
                 publish_with_metrics!(
-                    stream.publish(&subject, &payload),
+                    stream.publish_raw(
+                        &build_subject_name(predicate_tag, &subject),
+                        &payload
+                    ),
                     metrics,
                     chain_id,
                     block_producer,
                     InputsCoinSubject::WILDCARD
                 );
                 publish_with_metrics!(
-                    stream.publish(&by_id, &payload),
+                    stream.publish_raw(
+                        &build_subject_name(predicate_tag, &by_id_subject),
+                        &payload
+                    ),
                     metrics,
                     chain_id,
                     block_producer,
@@ -223,27 +213,42 @@ pub async fn publish(
                 );
             }
             InputSubject::Message(
-                by_id_sender,
-                by_id_recipient,
+                by_id_sender_subject,
+                by_id_recipient_subject,
                 subject,
                 payload,
             ) => {
                 publish_with_metrics!(
-                    stream.publish(&subject, &payload),
+                    stream.publish_raw(
+                        &build_subject_name(predicate_tag, &subject),
+                        &payload
+                    ),
                     metrics,
                     chain_id,
                     block_producer,
                     InputsMessageSubject::WILDCARD
                 );
                 publish_with_metrics!(
-                    stream.publish(&by_id_sender, &payload),
+                    stream.publish_raw(
+                        &build_subject_name(
+                            predicate_tag,
+                            &by_id_sender_subject
+                        ),
+                        &payload
+                    ),
                     metrics,
                     chain_id,
                     block_producer,
                     InputsByIdSubject::WILDCARD
                 );
                 publish_with_metrics!(
-                    stream.publish(&by_id_recipient, &payload),
+                    stream.publish_raw(
+                        &build_subject_name(
+                            predicate_tag,
+                            &by_id_recipient_subject
+                        ),
+                        &payload
+                    ),
                     metrics,
                     chain_id,
                     block_producer,

--- a/crates/fuel-streams-publisher/src/inputs.rs
+++ b/crates/fuel-streams-publisher/src/inputs.rs
@@ -9,7 +9,9 @@ use fuel_core_types::fuel_tx::{
 };
 use fuel_streams_core::{
     inputs::{
-        InputsByIdSubject, InputsCoinSubject, InputsContractSubject,
+        InputsByIdSubject,
+        InputsCoinSubject,
+        InputsContractSubject,
         InputsMessageSubject,
     },
     prelude::*,
@@ -19,7 +21,9 @@ use fuel_streams_core::{
 };
 
 use crate::{
-    build_subject_name, metrics::PublisherMetrics, publish_with_metrics,
+    build_subject_name,
+    metrics::PublisherMetrics,
+    publish_with_metrics,
 };
 
 fn coin_subject<T: CoinSpecification>(

--- a/crates/fuel-streams-publisher/src/lib.rs
+++ b/crates/fuel-streams-publisher/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 mod inputs;
 mod logs;
 mod outputs;
+pub mod predicates;
 mod publisher;
 mod receipts;
 mod transactions;

--- a/crates/fuel-streams-publisher/src/lib.rs
+++ b/crates/fuel-streams-publisher/src/lib.rs
@@ -17,4 +17,16 @@ pub mod state;
 pub mod system;
 
 pub use fuel_core::{FuelCore, FuelCoreLike};
+use fuel_streams_core::prelude::*;
 pub use publisher::{Publisher, Streams};
+
+fn build_subject_name(
+    predicate_tag: &Option<Bytes32>,
+    subject: &dyn IntoSubject,
+) -> String {
+    let subject_name = subject.parse();
+    match predicate_tag {
+        Some(tag) => format!("predicates.{tag}.{subject_name}"),
+        None => subject_name,
+    }
+}

--- a/crates/fuel-streams-publisher/src/logs.rs
+++ b/crates/fuel-streams-publisher/src/logs.rs
@@ -1,54 +1,50 @@
 use std::sync::Arc;
 
 use fuel_core_types::fuel_tx::Receipt;
-use fuel_streams_core::{
-    logs::LogsSubject,
-    prelude::*,
-    types::{Transaction, UniqueIdentifier},
-    Stream,
-};
+use fuel_streams_core::{logs::LogsSubject, prelude::*, Stream};
 use tracing::info;
 
-use crate::{metrics::PublisherMetrics, publish_with_metrics, FuelCoreLike};
+use crate::{
+    build_subject_name,
+    metrics::PublisherMetrics,
+    publish_with_metrics,
+};
 
+#[allow(clippy::too_many_arguments)]
 pub async fn publish(
-    metrics: &Arc<PublisherMetrics>,
-    fuel_core: &dyn FuelCoreLike,
     logs_stream: &Stream<Log>,
-    transactions: &[Transaction],
-    block_producer: &Address,
+    receipts: Option<Vec<Receipt>>,
+    tx_id: Bytes32,
+    chain_id: &ChainId,
     block_height: BlockHeight,
+    metrics: &Arc<PublisherMetrics>,
+    block_producer: &Address,
+    predicate_tag: Option<Bytes32>,
 ) -> anyhow::Result<()> {
-    let chain_id = fuel_core.chain_id();
+    if let Some(receipts) = receipts {
+        for (index, receipt) in receipts.iter().enumerate() {
+            match receipt {
+                Receipt::Log { id, .. } | Receipt::LogData { id, .. } => {
+                    let subject = LogsSubject::new()
+                        .with_block_height(Some(block_height.clone()))
+                        .with_tx_id(Some(tx_id.clone()))
+                        .with_receipt_index(Some(index))
+                        .with_log_id(Some((*id).into()));
+                    let subject_wildcard = LogsSubject::WILDCARD;
 
-    for transaction in transactions.iter() {
-        let tx_id = transaction.id(chain_id);
-        let receipts = fuel_core.get_receipts(&tx_id)?;
-
-        if let Some(receipts) = receipts {
-            for (index, receipt) in receipts.iter().enumerate() {
-                match receipt {
-                    receipt @ (Receipt::Log { id, .. }
-                    | Receipt::LogData { id, .. }) => {
-                        let subject = LogsSubject::new()
-                            .with_block_height(Some(block_height.clone()))
-                            .with_tx_id(Some(tx_id.into()))
-                            .with_receipt_index(Some(index))
-                            .with_log_id(Some((*id).into()));
-                        let subject_wildcard = LogsSubject::WILDCARD;
-
-                        info!("NATS Publisher: Publishing Logs for 0x#{tx_id}");
-                        publish_with_metrics!(
-                            logs_stream
-                                .publish(&subject, &(receipt.clone()).into()),
-                            metrics,
-                            chain_id,
-                            block_producer,
-                            subject_wildcard
-                        );
-                    }
-                    _non_log_receipt => {}
+                    info!("NATS Publisher: Publishing Logs for 0x#{tx_id}");
+                    publish_with_metrics!(
+                        logs_stream.publish_raw(
+                            &build_subject_name(&predicate_tag, &subject),
+                            &(receipt.clone()).into(),
+                        ),
+                        metrics,
+                        chain_id,
+                        block_producer,
+                        subject_wildcard
+                    );
                 }
+                _non_log_receipt => {}
             }
         }
     }

--- a/crates/fuel-streams-publisher/src/outputs.rs
+++ b/crates/fuel-streams-publisher/src/outputs.rs
@@ -20,7 +20,7 @@ pub async fn publish(
     stream: &Stream<fuel_core_types::fuel_tx::Output>,
     chain_id: &ChainId,
     transaction: &Transaction,
-    predicate_tag: &Option<Bytes32>,
+    predicate_tag: Option<Bytes32>,
 ) -> anyhow::Result<()> {
     let tx_id = transaction.id(chain_id);
     let outputs = transaction.outputs();
@@ -94,9 +94,9 @@ pub async fn publish(
             ),
         };
 
-        let subject_name = build_subject_name(predicate_tag, &*subject);
+        let subject_name = build_subject_name(&predicate_tag, &*subject);
         let by_id_subject_name =
-            build_subject_name(predicate_tag, &by_id_subject);
+            build_subject_name(&predicate_tag, &by_id_subject);
 
         stream.publish_raw(&subject_name, output).await?;
         stream.publish_raw(&by_id_subject_name, output).await?;

--- a/crates/fuel-streams-publisher/src/outputs.rs
+++ b/crates/fuel-streams-publisher/src/outputs.rs
@@ -1,9 +1,4 @@
-use fuel_core_types::fuel_tx::{
-    field::Outputs,
-    Bytes32,
-    Output,
-    UniqueIdentifier,
-};
+use fuel_core_types::fuel_tx::{Output, UniqueIdentifier};
 use fuel_streams_core::{
     outputs::{
         OutputsByIdSubject,
@@ -14,121 +9,97 @@ use fuel_streams_core::{
         OutputsVariableSubject,
     },
     prelude::*,
+    transactions::{WithTxInputs, WithTxOutputs},
     types::{ChainId, IdentifierKind, Transaction},
     Stream,
 };
 
-macro_rules! get_outputs {
-    ($transaction:expr, $($variant:ident),+) => {
-        match $transaction {
-            Transaction::Mint(_) => vec![],
-            $(Transaction::$variant(tx) => tx.outputs().to_vec(),)+
-        }
-    };
-}
-
-fn outputs_from_transaction(transaction: &Transaction) -> Vec<Output> {
-    get_outputs!(transaction, Script, Blob, Create, Upload, Upgrade)
-}
-
-macro_rules! get_inputs {
-    ($transaction:expr, $($variant:ident),+) => {
-        match $transaction {
-            Transaction::Mint(_) => vec![],
-            $(Transaction::$variant(tx) => tx.inputs().to_vec(),)+
-        }
-    };
-}
-
-fn inputs_from_transaction(transaction: &Transaction) -> Vec<Input> {
-    get_inputs!(transaction, Script, Blob, Create, Upload, Upgrade)
-}
+use crate::build_subject_name;
 
 pub async fn publish(
     stream: &Stream<fuel_core_types::fuel_tx::Output>,
     chain_id: &ChainId,
-    transactions: &[Transaction],
+    transaction: &Transaction,
+    predicate_tag: &Option<Bytes32>,
 ) -> anyhow::Result<()> {
-    for transaction in transactions {
-        let tx_id = transaction.id(chain_id);
-        let outputs = outputs_from_transaction(transaction);
-        for (index, output) in outputs.iter().enumerate() {
-            let (subject, by_id_subject): (
-                Box<dyn IntoSubject>,
-                OutputsByIdSubject,
-            ) = match output {
-                Output::Coin { to, asset_id, .. } => (
-                    OutputsCoinSubject::new()
+    let tx_id = transaction.id(chain_id);
+    let outputs = transaction.outputs();
+    for (index, output) in outputs.iter().enumerate() {
+        let (subject, by_id_subject): (
+            Box<dyn IntoSubject>,
+            OutputsByIdSubject,
+        ) = match output {
+            Output::Coin { to, asset_id, .. } => (
+                OutputsCoinSubject::new()
+                    .with_tx_id(Some(tx_id.into()))
+                    .with_index(Some(index as u16))
+                    .with_to(Some((*to).into()))
+                    .with_asset_id(Some((*asset_id).into()))
+                    .boxed(),
+                OutputsByIdSubject::new()
+                    .with_id_kind(Some(IdentifierKind::Address))
+                    .with_id_value(Some(Bytes32::from(*to))),
+            ),
+            Output::Contract(contract) => {
+                let input_index = contract.input_index as usize;
+                let contract_id = if let Input::Contract(input_contract) =
+                    &transaction.inputs()[input_index]
+                {
+                    input_contract.contract_id
+                } else {
+                    anyhow::bail!("Contract input not found");
+                };
+                (
+                    OutputsContractSubject::new()
                         .with_tx_id(Some(tx_id.into()))
                         .with_index(Some(index as u16))
-                        .with_to(Some((*to).into()))
-                        .with_asset_id(Some((*asset_id).into()))
-                        .boxed(),
-                    OutputsByIdSubject::new()
-                        .with_id_kind(Some(IdentifierKind::Address))
-                        .with_id_value(Some(Bytes32::new((*to).into()).into())),
-                ),
-                Output::Contract(contract) => {
-                    let input_index = contract.input_index as usize;
-                    let contract_id = if let Input::Contract(input_contract) =
-                        &inputs_from_transaction(transaction)[input_index]
-                    {
-                        input_contract.contract_id
-                    } else {
-                        anyhow::bail!("Contract input not found");
-                    };
-                    (
-                        OutputsContractSubject::new()
-                            .with_tx_id(Some(tx_id.into()))
-                            .with_index(Some(index as u16))
-                            .with_contract_id(Some(contract_id.into()))
-                            .boxed(),
-                        OutputsByIdSubject::new()
-                            .with_id_kind(Some(IdentifierKind::ContractID))
-                            .with_id_value(Some(
-                                Bytes32::new(contract_id.into()).into(),
-                            )),
-                    )
-                }
-                Output::Change { to, asset_id, .. } => (
-                    OutputsChangeSubject::new()
-                        .with_tx_id(Some(tx_id.into()))
-                        .with_index(Some(index as u16))
-                        .with_to(Some((*to).into()))
-                        .with_asset_id(Some((*asset_id).into()))
-                        .boxed(),
-                    OutputsByIdSubject::new()
-                        .with_id_kind(Some(IdentifierKind::Address))
-                        .with_id_value(Some(Bytes32::new((*to).into()).into())),
-                ),
-                Output::Variable { to, asset_id, .. } => (
-                    OutputsVariableSubject::new()
-                        .with_tx_id(Some(tx_id.into()))
-                        .with_index(Some(index as u16))
-                        .with_to(Some((*to).into()))
-                        .with_asset_id(Some((*asset_id).into()))
-                        .boxed(),
-                    OutputsByIdSubject::new()
-                        .with_id_kind(Some(IdentifierKind::Address))
-                        .with_id_value(Some(Bytes32::new((*to).into()).into())),
-                ),
-                Output::ContractCreated { contract_id, .. } => (
-                    OutputsContractCreatedSubject::new()
-                        .with_tx_id(Some(tx_id.into()))
-                        .with_index(Some(index as u16))
-                        .with_contract_id(Some((*contract_id).into()))
+                        .with_contract_id(Some(contract_id.into()))
                         .boxed(),
                     OutputsByIdSubject::new()
                         .with_id_kind(Some(IdentifierKind::ContractID))
-                        .with_id_value(Some(
-                            Bytes32::new((*contract_id).into()).into(),
-                        )),
-                ),
-            };
+                        .with_id_value(Some(Bytes32::from(*contract_id))),
+                )
+            }
+            Output::Change { to, asset_id, .. } => (
+                OutputsChangeSubject::new()
+                    .with_tx_id(Some(tx_id.into()))
+                    .with_index(Some(index as u16))
+                    .with_to(Some((*to).into()))
+                    .with_asset_id(Some((*asset_id).into()))
+                    .boxed(),
+                OutputsByIdSubject::new()
+                    .with_id_kind(Some(IdentifierKind::Address))
+                    .with_id_value(Some(Bytes32::from(*to))),
+            ),
+            Output::Variable { to, asset_id, .. } => (
+                OutputsVariableSubject::new()
+                    .with_tx_id(Some(tx_id.into()))
+                    .with_index(Some(index as u16))
+                    .with_to(Some((*to).into()))
+                    .with_asset_id(Some((*asset_id).into()))
+                    .boxed(),
+                OutputsByIdSubject::new()
+                    .with_id_kind(Some(IdentifierKind::Address))
+                    .with_id_value(Some(Bytes32::from(*to))),
+            ),
+            Output::ContractCreated { contract_id, .. } => (
+                OutputsContractCreatedSubject::new()
+                    .with_tx_id(Some(tx_id.into()))
+                    .with_index(Some(index as u16))
+                    .with_contract_id(Some((*contract_id).into()))
+                    .boxed(),
+                OutputsByIdSubject::new()
+                    .with_id_kind(Some(IdentifierKind::ContractID))
+                    .with_id_value(Some(Bytes32::from(*contract_id))),
+            ),
+        };
 
-            stream.publish(&*subject, output).await?;
-            stream.publish(&by_id_subject, output).await?;
-        }
+        let subject_name = build_subject_name(predicate_tag, &*subject);
+        let by_id_subject_name =
+            build_subject_name(predicate_tag, &by_id_subject);
+
+        stream.publish_raw(&subject_name, output).await?;
+        stream.publish_raw(&by_id_subject_name, output).await?;
     }
 
     Ok(())

--- a/crates/fuel-streams-publisher/src/predicates.rs
+++ b/crates/fuel-streams-publisher/src/predicates.rs
@@ -1,0 +1,14 @@
+use fuel_streams_core::types::Bytes32;
+use sha2::{Digest, Sha256};
+
+pub fn tag(bytecode: &[u8]) -> Bytes32 {
+    let mut sha256 = Sha256::new();
+    sha256.update(bytecode);
+    let bytes: [u8; 32] = sha256
+        .finalize()
+        .as_slice()
+        .try_into()
+        .expect("Must be 32 bytes");
+
+    bytes.into()
+}

--- a/crates/fuel-streams-publisher/src/publisher.rs
+++ b/crates/fuel-streams-publisher/src/publisher.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use async_nats::{jetstream::stream::State as StreamState, RequestErrorKind};
 use fuel_core::database::database_description::DatabaseHeight;
@@ -506,7 +506,12 @@ impl Publisher {
             }
         }
 
+        let start_time = Instant::now();
         try_join_all(publishing_tasks).await?;
+        tracing::info!(
+            "Published streams for BlockHeight: {block_height} in {:?} ms",
+            start_time.elapsed().as_millis()
+        );
 
         Ok(())
     }

--- a/crates/fuel-streams-publisher/src/receipts.rs
+++ b/crates/fuel-streams-publisher/src/receipts.rs
@@ -18,11 +18,11 @@ use crate::{
 pub async fn publish(
     receipts_stream: &Stream<Receipt>,
     receipts: Option<Vec<Receipt>>,
-    tx_id: &Bytes32,
+    tx_id: Bytes32,
     chain_id: ChainId,
     metrics: &Arc<PublisherMetrics>,
     block_producer: &Address,
-    predicate_tag: &Option<Bytes32>,
+    predicate_tag: Option<Bytes32>,
 ) -> anyhow::Result<()> {
     if let Some(receipts) = receipts {
         info!("NATS Publisher: Publishing Receipts for 0x#{tx_id}");
@@ -33,7 +33,7 @@ pub async fn publish(
             for (index, subject) in subjects.iter().enumerate() {
                 publish_with_metrics!(
                     receipts_stream.publish_raw(
-                        &build_subject_name(predicate_tag, &**subject),
+                        &build_subject_name(&predicate_tag, &**subject),
                         receipt
                     ),
                     metrics,

--- a/crates/fuel-streams-publisher/src/receipts.rs
+++ b/crates/fuel-streams-publisher/src/receipts.rs
@@ -4,43 +4,45 @@ use fuel_core_types::fuel_tx::Receipt;
 use fuel_streams_core::{
     prelude::*,
     receipts::*,
-    types::{IdentifierKind, Transaction, UniqueIdentifier},
+    types::IdentifierKind,
     Stream,
 };
 use tracing::info;
 
-use crate::{metrics::PublisherMetrics, publish_with_metrics, FuelCoreLike};
+use crate::{
+    build_subject_name,
+    metrics::PublisherMetrics,
+    publish_with_metrics,
+};
 
 pub async fn publish(
-    metrics: &Arc<PublisherMetrics>,
-    fuel_core: &dyn FuelCoreLike,
     receipts_stream: &Stream<Receipt>,
-    transactions: &[Transaction],
+    receipts: Option<Vec<Receipt>>,
+    tx_id: &Bytes32,
+    chain_id: ChainId,
+    metrics: &Arc<PublisherMetrics>,
     block_producer: &Address,
+    predicate_tag: &Option<Bytes32>,
 ) -> anyhow::Result<()> {
-    let chain_id = fuel_core.chain_id();
+    if let Some(receipts) = receipts {
+        info!("NATS Publisher: Publishing Receipts for 0x#{tx_id}");
 
-    for transaction in transactions.iter() {
-        let tx_id = transaction.id(chain_id);
-        let receipts = fuel_core.get_receipts(&tx_id)?;
-
-        if let Some(receipts) = receipts {
-            info!("NATS Publisher: Publishing Receipts for 0x#{tx_id}");
-
-            for (index, receipt) in receipts.iter().enumerate() {
-                let (subjects, subjects_wildcard) =
-                    receipt_subjects(receipt, tx_id.into(), index);
-                for (index, subject) in subjects.iter().enumerate() {
-                    publish_with_metrics!(
-                        receipts_stream.publish(&**subject, receipt),
-                        metrics,
-                        chain_id,
-                        block_producer,
-                        subjects_wildcard
-                            .get(index)
-                            .expect("Wildcard must be provided")
-                    );
-                }
+        for (index, receipt) in receipts.iter().enumerate() {
+            let (subjects, subjects_wildcard) =
+                receipt_subjects(receipt, tx_id.clone(), index);
+            for (index, subject) in subjects.iter().enumerate() {
+                publish_with_metrics!(
+                    receipts_stream.publish_raw(
+                        &build_subject_name(predicate_tag, &**subject),
+                        receipt
+                    ),
+                    metrics,
+                    chain_id,
+                    block_producer,
+                    subjects_wildcard
+                        .get(index)
+                        .expect("Wildcard must be provided")
+                );
             }
         }
     }

--- a/crates/fuel-streams-publisher/src/transactions.rs
+++ b/crates/fuel-streams-publisher/src/transactions.rs
@@ -6,7 +6,10 @@ use fuel_streams_core::{
     prelude::*,
     transactions::TransactionsSubject,
     types::{
-        BlockHeight, Transaction, TransactionKind, TransactionStatus,
+        BlockHeight,
+        Transaction,
+        TransactionKind,
+        TransactionStatus,
         UniqueIdentifier,
     },
     Stream,
@@ -14,7 +17,9 @@ use fuel_streams_core::{
 use tracing::info;
 
 use crate::{
-    build_subject_name, metrics::PublisherMetrics, publish_with_metrics,
+    build_subject_name,
+    metrics::PublisherMetrics,
+    publish_with_metrics,
     FuelCoreLike,
 };
 
@@ -42,7 +47,7 @@ pub async fn publish(
         .with_tx_id(Some(tx_id.into()))
         .with_kind(Some(kind))
         .with_status(Some(status))
-        .with_height(Some(block_height))
+        .with_block_height(Some(block_height))
         .with_tx_index(Some(transaction_index));
 
     info!("NATS Publisher: Publishing Transaction 0x#{tx_id}");

--- a/crates/fuel-streams-publisher/src/transactions.rs
+++ b/crates/fuel-streams-publisher/src/transactions.rs
@@ -6,55 +6,57 @@ use fuel_streams_core::{
     prelude::*,
     transactions::TransactionsSubject,
     types::{
-        BlockHeight,
-        Transaction,
-        TransactionKind,
-        TransactionStatus,
+        BlockHeight, Transaction, TransactionKind, TransactionStatus,
         UniqueIdentifier,
     },
     Stream,
 };
 use tracing::info;
 
-use crate::{metrics::PublisherMetrics, publish_with_metrics, FuelCoreLike};
+use crate::{
+    build_subject_name, metrics::PublisherMetrics, publish_with_metrics,
+    FuelCoreLike,
+};
 
 #[allow(clippy::too_many_arguments)]
 pub async fn publish(
-    metrics: &Arc<PublisherMetrics>,
-    fuel_core: &dyn FuelCoreLike,
     transactions_stream: &Stream<Transaction>,
-    transactions: &[Transaction],
-    block_producer: &Address,
+    (transaction_index, transaction): (usize, &Transaction),
+    fuel_core: &dyn FuelCoreLike,
     block_height: BlockHeight,
+    metrics: &Arc<PublisherMetrics>,
+    block_producer: &Address,
+    predicate_tag: &Option<Bytes32>,
 ) -> anyhow::Result<()> {
     let chain_id = fuel_core.chain_id();
     let off_chain_database = fuel_core.database().off_chain().latest_view()?;
 
-    for (transaction_index, transaction) in transactions.iter().enumerate() {
-        let tx_id = transaction.id(chain_id);
-        let kind = TransactionKind::from(transaction.to_owned());
-        let status: TransactionStatus = off_chain_database
-            .get_tx_status(&tx_id)?
-            .map(|status| status.into())
-            .unwrap_or_default();
+    let tx_id = transaction.id(chain_id);
+    let kind = TransactionKind::from(transaction.to_owned());
+    let status: TransactionStatus = off_chain_database
+        .get_tx_status(&tx_id)?
+        .map(|status| status.into())
+        .unwrap_or_default();
 
-        let transactions_subject = TransactionsSubject::new()
-            .with_tx_id(Some(tx_id.into()))
-            .with_kind(Some(kind))
-            .with_status(Some(status))
-            .with_block_height(Some(block_height.clone()))
-            .with_tx_index(Some(transaction_index));
+    let transactions_subject = TransactionsSubject::new()
+        .with_tx_id(Some(tx_id.into()))
+        .with_kind(Some(kind))
+        .with_status(Some(status))
+        .with_height(Some(block_height))
+        .with_tx_index(Some(transaction_index));
 
-        info!("NATS Publisher: Publishing Transaction 0x#{tx_id}");
+    info!("NATS Publisher: Publishing Transaction 0x#{tx_id}");
 
-        publish_with_metrics!(
-            transactions_stream.publish(&transactions_subject, transaction),
-            metrics,
-            chain_id,
-            block_producer,
-            TransactionsSubject::WILDCARD
-        );
-    }
+    publish_with_metrics!(
+        transactions_stream.publish_raw(
+            &build_subject_name(predicate_tag, &transactions_subject),
+            transaction,
+        ),
+        metrics,
+        chain_id,
+        block_producer,
+        TransactionsSubject::WILDCARD
+    );
 
     Ok(())
 }

--- a/crates/fuel-streams-publisher/src/transactions.rs
+++ b/crates/fuel-streams-publisher/src/transactions.rs
@@ -26,7 +26,7 @@ pub async fn publish(
     block_height: BlockHeight,
     metrics: &Arc<PublisherMetrics>,
     block_producer: &Address,
-    predicate_tag: &Option<Bytes32>,
+    predicate_tag: Option<Bytes32>,
 ) -> anyhow::Result<()> {
     let chain_id = fuel_core.chain_id();
     let off_chain_database = fuel_core.database().off_chain().latest_view()?;
@@ -49,7 +49,7 @@ pub async fn publish(
 
     publish_with_metrics!(
         transactions_stream.publish_raw(
-            &build_subject_name(predicate_tag, &transactions_subject),
+            &build_subject_name(&predicate_tag, &transactions_subject),
             transaction,
         ),
         metrics,


### PR DESCRIPTION
Closes: https://linear.app/fuel-network/issue/DS-65/predicates-implement-logic-on-core-and-publisher

Currently, it hashes the entire bytecode as the predicate tag. Once the sway team separates the configurable
from the actual bytecode, the tag fn implementation will need an update accordingly.