### PR TITLE
feat(data-parser): Change to MessagePack as default serializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,6 +3125,7 @@ dependencies = [
  "lazy_static",
  "paste",
  "postcard",
+ "rmp-serde",
  "serde",
  "serde_json",
  "strum 0.26.3",
@@ -6732,6 +6733,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
 ]
 
 [[package]]

--- a/benches/data-parser/benches/deserialize.rs
+++ b/benches/data-parser/benches/deserialize.rs
@@ -48,10 +48,10 @@ fn bench_deserialize(c: &mut Criterion) {
     for (serialization_type, compression_strategy, serialized) in
         serialized_data
     {
-        let bench_name = format!("[{}]", serialization_type.to_string());
+        let bench_name = format!("[{}]", serialization_type);
         group.bench_function(&bench_name, |b| {
             let data_parser = DataParser::default()
-                .with_compression_strategy(&compression_strategy)
+                .with_compression_strategy(compression_strategy)
                 .with_serialization_type(serialization_type.clone());
 
             b.iter(|| {

--- a/benches/data-parser/benches/serialize.rs
+++ b/benches/data-parser/benches/serialize.rs
@@ -25,7 +25,7 @@ fn bench_serialize(c: &mut Criterion) {
         .collect::<Vec<_>>();
 
     for (serialization_type, compression_strategy) in parametric_matrix {
-        let bench_name = format!("[{}]", serialization_type.to_string());
+        let bench_name = format!("[{}]", serialization_type);
 
         group.bench_function(bench_name, |b| {
             let data_parser = DataParser::default()

--- a/crates/fuel-data-parser/Cargo.toml
+++ b/crates/fuel-data-parser/Cargo.toml
@@ -18,6 +18,7 @@ displaydoc = { workspace = true }
 lazy_static = "1.5"
 paste = "1.0.15"
 postcard = { version = "1.0.8", features = ["alloc"] }
+rmp-serde = "1.3.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true, features = ["derive"] }

--- a/crates/fuel-data-parser/src/error.rs
+++ b/crates/fuel-data-parser/src/error.rs
@@ -31,6 +31,10 @@ pub enum SerdeError {
     Postcard(#[from] postcard::Error),
     /// Failed to serialize or deserialize data using JSON: {0}
     Json(#[from] serde_json::Error),
+    /// Failed to serialize data using MessagePack: {0}
+    MessagePackEncode(#[from] rmp_serde::encode::Error),
+    /// Failed to deserialize data using MessagePack: {0}
+    MessagePackDecode(#[from] rmp_serde::decode::Error),
 }
 
 /// Data parser error types.


### PR DESCRIPTION
By checking [Rust Serialization Benchmarks](https://david.kolo.ski/rust_serialization_benchmark/), MessagePack seems an excellent alternative that meets our requirements. It's faster than JSON and slower than Postcard, but it supports other languages like Typescript and doesn't need to define schemas like Protobuf.