### PR TITLE
feat(publisher): Cleanup the return type of Publisher::run()

### DIFF
--- a/crates/fuel-streams-publisher/src/main.rs
+++ b/crates/fuel-streams-publisher/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
 
-    let publisher = fuel_streams_publisher::Publisher::new(
+    let mut publisher = fuel_streams_publisher::Publisher::new(
         state.fuel_service.clone(),
         &cli.nats_url,
         state.metrics.clone(),

--- a/crates/fuel-streams-publisher/src/publisher.rs
+++ b/crates/fuel-streams-publisher/src/publisher.rs
@@ -227,7 +227,7 @@ impl Publisher {
         Ok(())
     }
 
-    pub async fn run(mut self) -> anyhow::Result<Self> {
+    pub async fn run(&mut self) -> anyhow::Result<()> {
         let mut stop_handle = StopHandle::new();
         stop_handle.spawn_signal_listener();
 
@@ -257,7 +257,7 @@ impl Publisher {
                         if shutdown {
                             tracing::info!("Shutdown signal received during historical blocks processing. Last published block height {height}");
                             self.shutdown_services_with_timeout().await?;
-                            return Ok(self);
+                            return Ok(());
                         }
                     },
                     (result, block_producer) = async {
@@ -303,7 +303,7 @@ impl Publisher {
             }
         }
 
-        Ok(self)
+        Ok(())
     }
 
     async fn publish(

--- a/tests/tests/publisher.rs
+++ b/tests/tests/publisher.rs
@@ -70,11 +70,11 @@ async fn doesnt_publish_any_message_when_no_block_has_been_mined() {
     let (_, blocks_subscription) = broadcast::channel::<ImporterResult>(1);
     let fuel_core = TestFuelCore::default(blocks_subscription).boxed();
 
-    let publisher =
+    let mut publisher =
         Publisher::default_with_publisher(&nats_client().await, fuel_core)
             .await
             .unwrap();
-    let publisher = publisher.run().await.unwrap();
+    publisher.run().await.unwrap();
 
     assert!(publisher.get_streams().is_empty().await);
 }
@@ -95,11 +95,11 @@ async fn publishes_a_block_message_when_a_single_block_has_been_mined() {
     drop(blocks_subscriber);
 
     let fuel_core = TestFuelCore::default(blocks_subscription).boxed();
-    let publisher =
+    let mut publisher =
         Publisher::default_with_publisher(&nats_client().await, fuel_core)
             .await
             .unwrap();
-    let publisher = publisher.run().await.unwrap();
+    publisher.run().await.unwrap();
 
     assert!(publisher
         .get_streams()
@@ -135,11 +135,11 @@ async fn publishes_transaction_for_each_published_block() {
     drop(blocks_subscriber);
 
     let fuel_core = TestFuelCore::default(blocks_subscription).boxed();
-    let publisher =
+    let mut publisher =
         Publisher::default_with_publisher(&nats_client().await, fuel_core)
             .await
             .unwrap();
-    let publisher = publisher.run().await.unwrap();
+    publisher.run().await.unwrap();
 
     assert!(publisher
         .get_streams()
@@ -262,12 +262,12 @@ async fn publishes_receipts() {
         .with_receipts(receipts.to_vec())
         .boxed();
 
-    let publisher =
+    let mut publisher =
         Publisher::default_with_publisher(&nats_client().await, fuel_core)
             .await
             .unwrap();
 
-    let publisher = publisher.run().await.unwrap();
+    publisher.run().await.unwrap();
 
     let mut receipts_stream =
         publisher.get_streams().receipts.catchup(10).await.unwrap();
@@ -318,12 +318,12 @@ async fn publishes_logs() {
         .with_receipts(vec![receipt.clone()])
         .boxed();
 
-    let publisher =
+    let mut publisher =
         Publisher::default_with_publisher(&nats_client().await, fuel_core)
             .await
             .unwrap();
 
-    let publisher = publisher.run().await.unwrap();
+    publisher.run().await.unwrap();
 
     assert!(publisher
         .get_streams()


### PR DESCRIPTION
```
pub async fn run(mut self) -> anyhow::Result<Self>
```

is rather odd. Internally, it loops forever (until shutdown). It is confusing that it returns `Self` (i.e. `Publisher`).

Normally, such functions return `()`.

```
let publisher = publisher.run().await.unwrap();
```

This is also an anti-pattern.

This PR changes this and replaces the uses as shown above with more idiomatic Rust.