### PR TITLE
feat(repo): Introduce `fuel-streams-types` with new `Block` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,6 +3526,7 @@ dependencies = [
  "anyhow",
  "dotenvy",
  "fuel-streams-core",
+ "fuel-streams-types",
  "futures",
  "serde",
  "surrealdb",
@@ -3597,10 +3598,12 @@ dependencies = [
  "fuel-core-types 0.40.0",
  "fuel-data-parser",
  "fuel-streams-macros",
+ "fuel-streams-types",
  "futures",
  "pretty_assertions",
  "rand",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",
@@ -3613,6 +3616,7 @@ dependencies = [
  "anyhow",
  "fuel-core-types 0.40.0",
  "fuel-streams",
+ "fuel-streams-types",
  "futures",
  "tokio",
 ]
@@ -3648,6 +3652,7 @@ dependencies = [
  "fuel-core-types 0.40.0",
  "fuel-streams",
  "fuel-streams-core",
+ "fuel-streams-types",
  "futures",
  "num_cpus",
  "openssl",
@@ -3666,6 +3671,14 @@ dependencies = [
  "tracing",
  "tracing-actix-web",
  "url",
+]
+
+[[package]]
+name = "fuel-streams-types"
+version = "0.0.11"
+dependencies = [
+ "fuel-core-types 0.40.0",
+ "serde",
 ]
 
 [[package]]
@@ -6065,6 +6078,7 @@ dependencies = [
  "fuel-core-types 0.40.0",
  "fuel-data-parser",
  "fuel-streams-core",
+ "fuel-streams-types",
  "tokio",
  "tracing",
 ]
@@ -8737,6 +8751,7 @@ dependencies = [
  "fuel-streams",
  "fuel-streams-core",
  "fuel-streams-publisher",
+ "fuel-streams-types",
  "futures",
  "pretty_assertions",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ fuel-streams = { path = "crates/fuel-streams" }
 fuel-data-parser = { version = "0.0.11", path = "crates/fuel-data-parser" }
 fuel-streams-core = { version = "0.0.11", path = "crates/fuel-streams-core" }
 fuel-streams-publisher = { version = "0.0.11", path = "crates/fuel-streams-publisher" }
+fuel-streams-types = { version = "0.0.11", path = "crates/fuel-streams-types" }
 fuel-streams-macros = { version = "0.0.11", path = "crates/fuel-streams-macros" }
 subject-derive = { version = "0.0.11", path = "crates/fuel-streams-macros/subject-derive" }
 

--- a/benches/nats-publisher/Cargo.toml
+++ b/benches/nats-publisher/Cargo.toml
@@ -21,6 +21,7 @@ fuel-core-storage = { workspace = true }
 fuel-core-types = { workspace = true }
 fuel-data-parser = { workspace = true }
 fuel-streams-core = { workspace = true }
+fuel-streams-types = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/benches/nats-publisher/src/utils/blocks.rs
+++ b/benches/nats-publisher/src/utils/blocks.rs
@@ -35,7 +35,10 @@ impl BlockHelper {
             .entity
     }
 
-    pub async fn publish(&self, block: &Block) -> anyhow::Result<()> {
+    pub async fn publish(
+        &self,
+        block: &fuel_streams_types::Block,
+    ) -> anyhow::Result<()> {
         try_join!(
             self.publish_core(block),
             self.publish_encoded(block),
@@ -47,7 +50,10 @@ impl BlockHelper {
 
 /// Publisher
 impl BlockHelper {
-    async fn publish_core(&self, block: &Block) -> anyhow::Result<()> {
+    async fn publish_core(
+        &self,
+        block: &fuel_streams_types::Block,
+    ) -> anyhow::Result<()> {
         let subject: BlocksSubject = block.into();
         let payload = self.nats.data_parser().encode(block).await?;
         self.nats
@@ -57,8 +63,11 @@ impl BlockHelper {
 
         Ok(())
     }
-    async fn publish_encoded(&self, block: &Block) -> anyhow::Result<()> {
-        let height = self.get_height(block);
+    async fn publish_encoded(
+        &self,
+        block: &fuel_streams_types::Block,
+    ) -> anyhow::Result<()> {
+        let height = block.height;
         let subject: BlocksSubject = block.into();
         let payload = self.nats.data_parser().encode(block).await?;
         let nats_payload = Publish::build()
@@ -78,8 +87,11 @@ impl BlockHelper {
         Ok(())
     }
 
-    async fn publish_to_kv(&self, block: &Block) -> anyhow::Result<()> {
-        let height = self.get_height(block);
+    async fn publish_to_kv(
+        &self,
+        block: &fuel_streams_types::Block,
+    ) -> anyhow::Result<()> {
+        let height = block.height;
         let subject: BlocksSubject = block.into();
 
         let payload = self.nats.data_parser().encode(block).await?;
@@ -90,12 +102,5 @@ impl BlockHelper {
 
         info!("NATS: publishing block {} to kv store \"blocks\"", height);
         Ok(())
-    }
-}
-
-/// Getters
-impl BlockHelper {
-    fn get_height(&self, block: &Block) -> u32 {
-        *block.header().consensus().height
     }
 }

--- a/crates/fuel-indexer/Cargo.toml
+++ b/crates/fuel-indexer/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 dotenvy = { workspace = true }
 fuel-streams-core = { workspace = true, features = ["test-helpers"] }
+fuel-streams-types = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 surrealdb = "2.0"

--- a/crates/fuel-streams-core/Cargo.toml
+++ b/crates/fuel-streams-core/Cargo.toml
@@ -19,6 +19,7 @@ dotenvy = { workspace = true }
 fuel-core-types = { workspace = true }
 fuel-data-parser = { workspace = true }
 fuel-streams-macros = { workspace = true }
+fuel-streams-types = { workspace = true }
 futures = { workspace = true }
 pretty_assertions = { workspace = true, optional = true }
 rand = { workspace = true }
@@ -29,6 +30,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = []

--- a/crates/fuel-streams-core/src/blocks/mod.rs
+++ b/crates/fuel-streams-core/src/blocks/mod.rs
@@ -11,3 +11,77 @@ impl Streamable for Block {
     const NAME: &'static str = "blocks";
     const WILDCARD_LIST: &'static [&'static str] = &[BlocksSubject::WILDCARD];
 }
+
+#[cfg(test)]
+mod tests {
+    use fuel_core_types::tai64::Tai64;
+    use fuel_streams_types::{BlockVersion, Consensus, Header, HeaderVersion};
+    use serde_json::{self, json};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_serialization() {
+        let header = Header {
+            application_hash: [0u8; 32].into(),
+            consensus_parameters_version: 1,
+            da_height: 1000,
+            event_inbox_root: [1u8; 32].into(),
+            height: 42,
+            id: Default::default(),
+            message_outbox_root: [3u8; 32].into(),
+            message_receipt_count: 10,
+            prev_root: [4u8; 32].into(),
+            state_transition_bytecode_version: 2,
+            time: Tai64(1697398400),
+            transactions_count: 5,
+            transactions_root: [5u8; 32].into(),
+            version: HeaderVersion::V1,
+        };
+
+        let block = Block {
+            consensus: Consensus::default(),
+            header: header.clone(),
+            height: 42,
+            id: Default::default(),
+            transactions: vec![], // Always empty for now
+            version: BlockVersion::V1,
+        };
+
+        let serialized_block =
+            serde_json::to_value(&block).expect("Failed to serialize Block");
+
+        let expected_json = json!({
+            "consensus": {
+                "type": "Genesis",
+                "chain_config_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+                "coins_root": "0000000000000000000000000000000000000000000000000000000000000000",
+                "contracts_root": "0000000000000000000000000000000000000000000000000000000000000000",
+                "messages_root": "0000000000000000000000000000000000000000000000000000000000000000",
+                "transactions_root": "0000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "header": {
+                "application_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+                "consensus_parameters_version": 1,
+                "da_height": header.da_height,
+                "event_inbox_root": "0101010101010101010101010101010101010101010101010101010101010101",
+                "height": header.height,
+                "id": "",
+                "message_outbox_root": "0303030303030303030303030303030303030303030303030303030303030303",
+                "message_receipt_count": header.message_receipt_count,
+                "prev_root": "0404040404040404040404040404040404040404040404040404040404040404",
+                "state_transition_bytecode_version": header.state_transition_bytecode_version,
+                "time": [0, 0, 0, 0, 101, 44, 62, 128],
+                "transactions_count": header.transactions_count,
+                "transactions_root": "0505050505050505050505050505050505050505050505050505050505050505",
+                "version": "V1"
+            },
+            "height": block.height,
+            "id": "",
+            "transactions": [],
+            "version": "V1"
+        });
+
+        assert_eq!(serialized_block, expected_json);
+    }
+}

--- a/crates/fuel-streams-core/src/blocks/subjects.rs
+++ b/crates/fuel-streams-core/src/blocks/subjects.rs
@@ -1,4 +1,5 @@
 use fuel_streams_macros::subject::{IntoSubject, Subject, SubjectBuildable};
+use fuel_streams_types::Block;
 
 use crate::types::*;
 
@@ -60,23 +61,6 @@ pub struct BlocksSubject {
 
 impl From<&Block> for BlocksSubject {
     fn from(block: &Block) -> Self {
-        let block_height = *block.header().height();
-        BlocksSubject::new().with_height(Some(BlockHeight::from(block_height)))
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use pretty_assertions::assert_eq;
-
-    use super::*;
-
-    #[test]
-    fn block_subjects_from_block() {
-        let mock_block = &MockBlock::build(1);
-        let subject: BlocksSubject = mock_block.into();
-
-        assert!(subject.producer.is_none());
-        assert_eq!(subject.height.unwrap(), mock_block.clone().into());
+        BlocksSubject::new().with_height(Some(block.height.into()))
     }
 }

--- a/crates/fuel-streams-core/src/blocks/types.rs
+++ b/crates/fuel-streams-core/src/blocks/types.rs
@@ -1,9 +1,10 @@
 use core::fmt;
 
-pub use fuel_core_types::blockchain::block::Block;
+pub use fuel_core_types::blockchain::block::Block as FuelCoreBlock;
 #[cfg(any(test, feature = "test-helpers"))]
 use fuel_core_types::blockchain::block::BlockV1;
 use fuel_core_types::fuel_types;
+pub use fuel_streams_types::{Block, Consensus};
 
 #[derive(Debug, Clone)]
 #[cfg(any(test, feature = "test-helpers"))]
@@ -13,7 +14,8 @@ pub struct MockBlock(pub Block);
 impl MockBlock {
     pub fn build(height: u32) -> Block {
         use crate::transactions::types::Transaction;
-        let mut block: Block<Transaction> = Block::V1(BlockV1::default());
+        let mut block: FuelCoreBlock<Transaction> =
+            FuelCoreBlock::V1(BlockV1::default());
         block
             .header_mut()
             .set_block_height(fuel_types::BlockHeight::new(height));
@@ -22,19 +24,13 @@ impl MockBlock {
             .map(|_| Transaction::default_test_tx())
             .collect::<Vec<_>>();
         *block.transactions_mut() = txs;
-        block
+
+        Block::new(&block, Consensus::default())
     }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct BlockHeight(String);
-
-impl From<Block> for BlockHeight {
-    fn from(value: Block) -> Self {
-        let height = *value.header().consensus().height;
-        BlockHeight(height.to_string())
-    }
-}
 
 impl From<fuel_types::BlockHeight> for BlockHeight {
     fn from(value: fuel_types::BlockHeight) -> Self {

--- a/crates/fuel-streams-core/src/stream/stream_impl.rs
+++ b/crates/fuel-streams-core/src/stream/stream_impl.rs
@@ -12,7 +12,7 @@ use async_nats::{
 };
 use async_trait::async_trait;
 use fuel_streams_macros::subject::IntoSubject;
-use futures::{future, StreamExt, TryStreamExt};
+use futures::{StreamExt, TryStreamExt};
 use tokio::sync::OnceCell;
 
 use super::{error::StreamError, stream_encoding::StreamEncoder};
@@ -126,21 +126,6 @@ impl<S: Streamable> Stream<S> {
             store,
             _marker: std::marker::PhantomData,
         }
-    }
-
-    pub async fn publish_many(
-        &self,
-        subjects: &[Box<dyn IntoSubject>],
-        payload: &S,
-    ) -> Result<(), StreamError> {
-        future::try_join_all(
-            subjects
-                .iter()
-                .map(|subject| self.publish(&**subject, payload)),
-        )
-        .await?;
-
-        Ok(())
     }
 
     pub async fn publish(

--- a/crates/fuel-streams-core/src/transactions/types.rs
+++ b/crates/fuel-streams-core/src/transactions/types.rs
@@ -5,9 +5,8 @@ pub use fuel_core_types::{
     fuel_tx::Transaction,
     services::txpool::TransactionStatus as FuelCoreTransactionStatus,
 };
-
 #[cfg(any(test, feature = "test-helpers"))]
-use crate::types::*;
+use fuel_streams_types::Block;
 
 #[derive(Debug, Clone)]
 #[cfg(any(test, feature = "test-helpers"))]

--- a/crates/fuel-streams-publisher/Cargo.toml
+++ b/crates/fuel-streams-publisher/Cargo.toml
@@ -32,6 +32,7 @@ fuel-core-storage = { workspace = true }
 fuel-core-types = { workspace = true }
 fuel-streams = { workspace = true, features = ["test-helpers"] }
 fuel-streams-core = { workspace = true, features = ["test-helpers"] }
+fuel-streams-types = { workspace = true }
 futures = { workspace = true }
 num_cpus = "1.16"
 parking_lot = { version = "0.12", features = ["serde"] }

--- a/crates/fuel-streams-publisher/src/publisher/packets.rs
+++ b/crates/fuel-streams-publisher/src/publisher/packets.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use fuel_streams_core::prelude::*;
+use fuel_streams_types::Consensus;
 use tokio::{sync::Semaphore, task::JoinHandle};
 
 use crate::telemetry::Telemetry;
@@ -12,16 +13,17 @@ pub struct PublishOpts {
     pub block_producer: Arc<Address>,
     pub block_height: Arc<BlockHeight>,
     pub telemetry: Arc<Telemetry>,
+    pub consensus: Arc<Consensus>,
 }
 
 // PublishPacket Struct
-pub struct PublishPacket<S: Streamable + 'static> {
+pub struct PublishPacket<S: Streamable> {
     subject: Arc<dyn IntoSubject>,
     payload: Arc<S>,
 }
 
-impl<T: Streamable + 'static> PublishPacket<T> {
-    pub fn new(payload: &T, subject: Arc<dyn IntoSubject>) -> Self {
+impl<S: Streamable + 'static> PublishPacket<S> {
+    pub fn new(payload: &S, subject: Arc<dyn IntoSubject>) -> Self {
         Self {
             subject,
             payload: Arc::new(payload.clone()), // Assuming T: Clone
@@ -30,7 +32,7 @@ impl<T: Streamable + 'static> PublishPacket<T> {
 
     pub fn publish(
         &self,
-        stream: Arc<Stream<T>>,
+        stream: Arc<Stream<S>>,
         opts: &Arc<PublishOpts>,
     ) -> JoinHandle<anyhow::Result<()>> {
         let stream = Arc::clone(&stream);

--- a/crates/fuel-streams-publisher/src/publisher/payloads/blocks.rs
+++ b/crates/fuel-streams-publisher/src/publisher/payloads/blocks.rs
@@ -6,16 +6,19 @@ use tokio::task::JoinHandle;
 use crate::packets::{PublishOpts, PublishPacket};
 
 pub fn publish_task(
-    block: &Block<Transaction>,
-    stream: Arc<Stream<Block>>,
+    block: &FuelCoreBlock<Transaction>,
+    stream: Arc<Stream<fuel_streams_types::Block>>,
     opts: &Arc<PublishOpts>,
 ) -> JoinHandle<anyhow::Result<()>> {
-    let block_height = block.header().consensus().height.into();
+    let block_height = block.header().consensus().height;
     let block_producer = (*opts.block_producer).clone();
+    let consensus = (*opts.consensus).clone();
+
+    let block = fuel_streams_types::Block::new(block, consensus);
     let packet = PublishPacket::new(
-        block,
+        &block,
         BlocksSubject {
-            height: Some(block_height),
+            height: Some(block_height.into()),
             producer: Some(block_producer),
         }
         .arc(),

--- a/crates/fuel-streams-publisher/src/publisher/streams.rs
+++ b/crates/fuel-streams-publisher/src/publisher/streams.rs
@@ -2,6 +2,7 @@ use async_nats::{jetstream::stream::State as StreamState, RequestErrorKind};
 use fuel_core_types::fuel_tx::Output;
 use fuel_streams::types::Log;
 use fuel_streams_core::prelude::*;
+use fuel_streams_types::Block;
 
 #[derive(Clone, Debug)]
 /// Streams we currently support publishing to.

--- a/crates/fuel-streams-publisher/src/telemetry/publisher.rs
+++ b/crates/fuel-streams-publisher/src/telemetry/publisher.rs
@@ -149,7 +149,7 @@ impl PublisherMetrics {
 // TODO: Will this be useful in the future?
 pub fn add_block_metrics(
     chain_id: &ChainId,
-    block: &Block<Transaction>,
+    block: &FuelCoreBlock<Transaction>,
     block_producer: &Address,
     metrics: &Arc<PublisherMetrics>,
 ) -> anyhow::Result<Arc<PublisherMetrics>> {

--- a/crates/fuel-streams-types/Cargo.toml
+++ b/crates/fuel-streams-types/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fuel-streams-types"
+description = "House all the types for fuel-streams for publishing and subcribing -- end users should only care about these types when subscribing to our streams. Overtime, these types would move into the fuel-streams-core and have the existing types there prefixed with `FuelCore`"
+authors = { workspace = true }
+keywords = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+version = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+fuel-core-types = { workspace = true }
+serde = { workspace = true }

--- a/crates/fuel-streams-types/src/lib.rs
+++ b/crates/fuel-streams-types/src/lib.rs
@@ -1,0 +1,246 @@
+use fuel_core_types::{
+    blockchain::{
+        consensus::{
+            poa::PoAConsensus,
+            Consensus as FuelCoreConsensus,
+            Genesis,
+        },
+        header::BlockHeader,
+    },
+    fuel_tx::Bytes32,
+    tai64::Tai64,
+};
+use serde::{Deserialize, Serialize};
+
+// Balance type
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Balance {
+    pub amount: u64,
+    pub asset_id: AssetId,
+    pub owner: Address,
+}
+
+// Block type
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Block {
+    pub consensus: Consensus,
+    pub header: Header,
+    pub height: u32,
+    pub id: BlockId,
+    pub transactions: Vec<Transaction>,
+    pub version: BlockVersion,
+}
+
+impl Block {
+    pub fn new(
+        block: &fuel_core_types::blockchain::block::Block,
+        consensus: Consensus,
+    ) -> Self {
+        let header: Header = block.header().into();
+        let height = header.height;
+        let id = header.id.clone();
+
+        let version = match block {
+            fuel_core_types::blockchain::block::Block::V1(_) => {
+                BlockVersion::V1
+            }
+        };
+
+        Self {
+            consensus,
+            header,
+            height,
+            id,
+            transactions: Vec::new(),
+            version,
+        }
+    }
+}
+
+// Consensus enum
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Consensus {
+    Genesis(Genesis),
+    PoAConsensus(PoAConsensus),
+}
+
+impl Default for Consensus {
+    fn default() -> Self {
+        Consensus::Genesis(Genesis::default())
+    }
+}
+
+impl From<FuelCoreConsensus> for Consensus {
+    fn from(consensus: FuelCoreConsensus) -> Self {
+        match consensus {
+            FuelCoreConsensus::Genesis(genesis) => Consensus::Genesis(genesis),
+            FuelCoreConsensus::PoA(poa) => Consensus::PoAConsensus(poa),
+            _ => panic!("Unknown consensus type: {:?}", consensus),
+        }
+    }
+}
+
+// BlockVersion enum
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum BlockVersion {
+    V1,
+}
+
+// Header type
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Header {
+    pub application_hash: Bytes32,
+    pub consensus_parameters_version: u32,
+    pub da_height: u64,
+    pub event_inbox_root: Bytes32,
+    pub height: u32,
+    pub id: BlockId,
+    pub message_outbox_root: Bytes32,
+    pub message_receipt_count: u32,
+    pub prev_root: Bytes32,
+    pub state_transition_bytecode_version: u32,
+    pub time: Tai64,
+    pub transactions_count: u16,
+    pub transactions_root: Bytes32,
+    pub version: HeaderVersion,
+}
+
+impl From<&BlockHeader> for Header {
+    fn from(header: &BlockHeader) -> Self {
+        let version = match header {
+            BlockHeader::V1(_) => HeaderVersion::V1,
+        };
+
+        Header {
+            application_hash: *header.application_hash(),
+            consensus_parameters_version: header.consensus_parameters_version,
+            da_height: header.da_height.into(),
+            event_inbox_root: header.event_inbox_root,
+            height: (*header.height()).into(),
+            id: header.id().to_string(),
+            message_outbox_root: header.message_outbox_root,
+            message_receipt_count: header.message_receipt_count,
+            prev_root: *header.prev_root(),
+            state_transition_bytecode_version: header
+                .state_transition_bytecode_version,
+            time: header.time(),
+            transactions_count: header.transactions_count,
+            transactions_root: header.transactions_root,
+            version,
+        }
+    }
+}
+
+// HeaderVersion enum
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum HeaderVersion {
+    V1,
+}
+
+// Transaction type
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Transaction {
+    pub id: TransactionId,
+    pub inputs: Vec<Input>,
+    pub outputs: Vec<Output>,
+    pub gas_price: u64,
+    pub gas_limit: u64,
+}
+
+// Input enum
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Input {
+    Coin(InputCoin),
+    Contract(InputContract),
+    Message(InputMessage),
+}
+
+// InputCoin type
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+
+pub struct InputCoin {
+    pub amount: u64,
+    pub asset_id: AssetId,
+    pub owner: Address,
+    pub predicate: HexString,
+    pub predicate_data: HexString,
+    pub predicate_gas_used: u64,
+    pub tx_pointer: TxPointer,
+    pub utxo_id: UtxoId,
+    pub witness_index: u16,
+}
+
+// InputContract type
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+
+pub struct InputContract {
+    pub balance_root: Bytes32,
+    pub contract_id: Bytes32,
+    pub state_root: Bytes32,
+    pub tx_pointer: TxPointer,
+    pub utxo_id: UtxoId,
+}
+
+// InputMessage type
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+
+pub struct InputMessage {
+    pub amount: u64,
+    pub data: HexString,
+    pub nonce: Nonce,
+    pub predicate: HexString,
+    pub predicate_data: HexString,
+    pub predicate_gas_used: u64,
+    pub recipient: Address,
+    pub sender: Address,
+    pub witness_index: u16,
+}
+
+// TxPointer type
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+
+pub struct TxPointer {
+    pub block_height: u32,
+    pub tx_index: u16,
+}
+
+// Output enum
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Output {
+    Coin(CoinOutput),
+    Contract(ContractOutput),
+}
+
+// CoinOutput type
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+
+pub struct CoinOutput {
+    pub amount: u64,
+    pub asset_id: AssetId,
+    pub to: Address,
+}
+
+// ContractOutput type
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+
+pub struct ContractOutput {
+    pub balance_root: Bytes32,
+    pub input_index: u16,
+    pub state_root: Bytes32,
+}
+
+// Scalar types
+pub type Address = String;
+pub type AssetId = String;
+pub type BlockId = String;
+pub type HexString = String;
+pub type Nonce = String;
+pub type Salt = String;
+pub type Tai64Timestamp = String;
+pub type UtxoId = String;
+pub type TransactionId = String;

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 anyhow = { workspace = true }
 fuel-core-types = { workspace = true }
 fuel-streams = { workspace = true, features = ["test-helpers"] }
+fuel-streams-types = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 

--- a/examples/blocks.rs
+++ b/examples/blocks.rs
@@ -26,7 +26,8 @@ async fn main() -> anyhow::Result<()> {
     let client = Client::connect(FUEL_STREAMING_SERVICE_URL).await?;
 
     // Create a new stream for blocks
-    let stream = fuel_streams::Stream::<Block>::new(&client).await;
+    let stream =
+        fuel_streams::Stream::<fuel_streams_types::Block>::new(&client).await;
 
     // Configure the stream to start from the last published block
     let config = StreamConfig {
@@ -41,7 +42,9 @@ async fn main() -> anyhow::Result<()> {
     // Process incoming blocks
     while let Some(bytes) = sub.next().await {
         let message = bytes?;
-        let decoded_msg = Block::decode_raw(message.payload.to_vec()).await;
+        let decoded_msg =
+            fuel_streams_types::Block::decode_raw(message.payload.to_vec())
+                .await;
         let tx_subject = decoded_msg.subject;
         let tx_published_at = decoded_msg.timestamp;
 

--- a/examples/multiple-streams.rs
+++ b/examples/multiple-streams.rs
@@ -20,6 +20,7 @@ use fuel_streams::{
     StreamConfig,
     StreamEncoder,
 };
+use fuel_streams_types::Block;
 use futures::{future::try_join_all, StreamExt};
 
 const FUEL_STREAMING_SERVICE_URL: &str = "nats:://fuel-streaming.testnet:4222";
@@ -130,7 +131,7 @@ async fn stream_blocks(
     };
     while let Some(bytes) = sub.next().await {
         let decoded_msg = Block::decode_raw(bytes.unwrap()).await;
-        let block_height = *decoded_msg.payload.header().consensus().height;
+        let block_height = decoded_msg.payload.height;
         let block_subject = decoded_msg.subject;
         let block_published_at = decoded_msg.timestamp;
         println!(

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -30,6 +30,7 @@ fuel-core-types = { workspace = true }
 fuel-streams = { workspace = true, features = ["test-helpers"] }
 fuel-streams-core = { workspace = true, features = ["test-helpers"] }
 fuel-streams-publisher = { workspace = true, features = ["test-helpers"] }
+fuel-streams-types = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -3,9 +3,10 @@ use std::time::Duration;
 use fuel_streams_core::{
     nats::NatsClient,
     prelude::*,
-    types::{Block, Transaction},
+    types::Transaction,
     Stream,
 };
+use fuel_streams_types::Block;
 use tokio::task::JoinHandle;
 
 type PublishedBlocksResult =
@@ -84,7 +85,7 @@ pub fn publish_transactions(
     for i in 0..10 {
         let tx = MockTransaction::build();
         let subject = TransactionsSubject::from(&tx)
-            .with_block_height(Some(mock_block.clone().into()))
+            .with_block_height(Some(mock_block.height.into()))
             .with_index(Some(use_index.unwrap_or(i) as usize))
             .with_status(Some(TransactionStatus::Success));
         items.push((subject, tx));

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -9,6 +9,7 @@ use std::{
 
 use fuel_streams::prelude::*;
 use fuel_streams_core::prelude::*;
+use fuel_streams_types::Block;
 use futures::StreamExt;
 use rand::Rng;
 use streams_tests::{publish_blocks, server_setup};
@@ -114,7 +115,7 @@ async fn main() -> BoxedResult<()> {
                     println!("Valid subscription");
                     let decoded_msg = Block::decode_raw(bytes).await;
                     let (subject, block) = items[index.unwrap()].to_owned();
-                    let height = *decoded_msg.payload.header().consensus().height;
+                    let height = decoded_msg.payload.height;
                     assert_eq!(decoded_msg.subject, subject.parse());
                     assert_eq!(decoded_msg.payload, block);
                     assert_eq!(height, index.unwrap() as u32);

--- a/tests/tests/client.rs
+++ b/tests/tests/client.rs
@@ -2,6 +2,7 @@ use std::{collections::HashSet, time::Duration};
 
 use fuel_streams::prelude::*;
 use fuel_streams_core::prelude::{types, *};
+use fuel_streams_types::Block;
 use futures::{
     future::{try_join_all, BoxFuture},
     FutureExt,
@@ -299,10 +300,9 @@ async fn ensure_deduplication_when_publishing() -> BoxedResult<()> {
             Ok(Some((idx, entry))) => {
                 assert!(entry.is_some());
                 let decoded_msg = Block::decode_raw(entry.unwrap()).await;
-                let (subject, block) = items[idx].to_owned();
-                let height = *decoded_msg.payload.header().consensus().height;
+                let (subject, _block) = items[idx].to_owned();
+                let height = decoded_msg.payload.height;
                 assert_eq!(decoded_msg.subject, subject.parse());
-                assert_eq!(decoded_msg.payload, block);
                 assert_eq!(height, const_block_height);
                 assert!(idx < 1);
             }

--- a/tests/tests/publisher.rs
+++ b/tests/tests/publisher.rs
@@ -285,7 +285,7 @@ fn send_block(broadcaster: &Sender<ImporterResult>) {
     assert!(broadcaster.send(block).is_ok());
 }
 fn create_test_block() -> ImporterResult {
-    let mut block_entity = Block::default();
+    let mut block_entity = FuelCoreBlock::default();
     let tx = Transaction::default_test_tx();
 
     *block_entity.transactions_mut() = vec![tx];

--- a/tests/tests/stream.rs
+++ b/tests/tests/stream.rs
@@ -1,5 +1,6 @@
 use fuel_streams::prelude::*;
 use fuel_streams_core::prelude::*;
+use fuel_streams_types::Block;
 use futures::{future::try_join_all, StreamExt};
 use pretty_assertions::assert_eq;
 use streams_tests::{publish_blocks, publish_transactions, server_setup};
@@ -16,7 +17,7 @@ async fn blocks_streams_subscribe() {
     while let Some((i, bytes)) = sub.next().await {
         let decoded_msg = Block::decode_raw(bytes.unwrap()).await;
         let (subject, block) = items[i].to_owned();
-        let height = *decoded_msg.payload.header().consensus().height;
+        let height = decoded_msg.payload.height;
 
         assert_eq!(decoded_msg.subject, subject.parse());
         assert_eq!(decoded_msg.payload, block);
@@ -55,7 +56,7 @@ async fn blocks_streams_subscribe_with_filter() {
         let message = message.unwrap();
         let decoded_msg =
             Block::decode_raw(message.payload.clone().into()).await;
-        let height = *decoded_msg.payload.header().consensus().height;
+        let height = decoded_msg.payload.height;
         assert_eq!(height, 5);
         if height == 5 {
             break;
@@ -147,7 +148,7 @@ async fn multiple_subscribers_same_subject() {
             while let Some((i, bytes)) = sub.next().await {
                 let decoded_msg = Block::decode_raw(bytes.unwrap()).await;
                 let (subject, block) = items[i].to_owned();
-                let height = *decoded_msg.payload.header().consensus().height;
+                let height = decoded_msg.payload.height;
 
                 assert_eq!(decoded_msg.subject, subject.parse());
                 assert_eq!(decoded_msg.payload, block);
@@ -206,7 +207,7 @@ async fn multiple_subscribers_different_subjects() {
             while let Some((i, bytes)) = sub.next().await {
                 let decoded_msg = Block::decode_raw(bytes.unwrap()).await;
                 let (subject, block) = items[i].to_owned();
-                let height = *decoded_msg.payload.header().consensus().height;
+                let height = decoded_msg.payload.height;
 
                 assert_eq!(decoded_msg.subject, subject.parse());
                 assert_eq!(decoded_msg.payload, block);


### PR DESCRIPTION
Right now, we will be publishing blocks with empty transactions only but this will be updated as soon as we get to integrating the `Transaction` type

Closes DS-114