### PR TITLE
feat(repo): Optional AWS assumable role

### DIFF
--- a/services/dune/src/s3/client.rs
+++ b/services/dune/src/s3/client.rs
@@ -50,7 +50,7 @@ impl Storage for S3Storage {
                 {
                     let provider =
                         aws_config::sts::AssumeRoleProvider::builder(
-                            assume_role_arn.parse().unwrap(),
+                            assume_role_arn,
                         )
                         .session_name("fuel_data_services_dune")
                         .configure(&base_config)

--- a/services/dune/src/s3/client.rs
+++ b/services/dune/src/s3/client.rs
@@ -1,8 +1,5 @@
 use async_trait::async_trait;
-use aws_config::{
-    default_provider::credentials::DefaultCredentialsChain,
-    BehaviorVersion,
-};
+use aws_config::BehaviorVersion;
 use aws_sdk_s3::{config::retry::RetryConfig as S3RetryConfig, Client};
 
 use super::{
@@ -44,9 +41,6 @@ impl Storage for S3Storage {
                 let base_config =
                     aws_config::defaults(BehaviorVersion::latest())
                         .region(config.region())
-                        .credentials_provider(
-                            DefaultCredentialsChain::builder().build().await,
-                        )
                         .load()
                         .await;
 
@@ -63,7 +57,7 @@ impl Storage for S3Storage {
                         .build()
                         .await;
 
-                    aws_config::from_env()
+                    aws_config::defaults(BehaviorVersion::latest())
                         .region(config.region())
                         .credentials_provider(provider)
                         .load()

--- a/services/dune/src/s3/client.rs
+++ b/services/dune/src/s3/client.rs
@@ -52,13 +52,16 @@ impl Storage for S3Storage {
 
                 // Support assuming a role for cross-account access
                 // or fallback to the default credential provider
-                if let Ok(assume_role_arn) = dotenvy::var("AWS_ASSUME_ROLE_ARN") {
+                if let Ok(assume_role_arn) = dotenvy::var("AWS_ASSUME_ROLE_ARN")
+                {
                     let provider =
-                        aws_config::sts::AssumeRoleProvider::builder(assume_role_arn.parse().unwrap())
-                            .session_name("fuel_data_services_dune")
-                            .configure(&base_config)
-                            .build()
-                            .await;
+                        aws_config::sts::AssumeRoleProvider::builder(
+                            assume_role_arn.parse().unwrap(),
+                        )
+                        .session_name("fuel_data_services_dune")
+                        .configure(&base_config)
+                        .build()
+                        .await;
 
                     aws_config::from_env()
                         .region(config.region())


### PR DESCRIPTION
This PR modifies the AWS SDK client to support optionally assuming a specified role. The current iteration assumes that a role will always need to be assumed, which is not always the case.

Also, the current code looks for `AWS_ROLE_ARN`, which is a reserved environment variable name by EKS, so this PR modifies it to `AWS_ASSUME_ROLE_ARN` so it is clear what the intention is when someone uses the value.