### PR TITLE
fix(repo): Reduce metrics cardinality

### DIFF
--- a/services/publisher/src/metrics.rs
+++ b/services/publisher/src/metrics.rs
@@ -1,18 +1,20 @@
 use async_trait::async_trait;
 use fuel_web_utils::telemetry::metrics::TelemetryMetrics;
 use prometheus::{
-    register_histogram_vec,
+    register_histogram,
     register_int_counter_vec,
-    HistogramVec,
+    register_int_counter,
+    Histogram,
     IntCounterVec,
+    IntCounter,
     Registry,
 };
 
 #[derive(Clone, Debug)]
 pub struct Metrics {
     pub registry: Registry,
-    pub published_messages_throughput: IntCounterVec,
-    pub message_size_histogram: HistogramVec,
+    pub published_messages_throughput: IntCounter,
+    pub message_size_histogram: Histogram,
     pub error_rates: IntCounterVec,
 }
 
@@ -44,17 +46,15 @@ impl Metrics {
             .map(|p| format!("{}_", p))
             .unwrap_or_default();
 
-        let published_messages_throughput = register_int_counter_vec!(
+        let published_messages_throughput = register_int_counter!(
             format!("{}publisher_metrics_messages_throughput", metric_prefix),
             "A metric counting the number of published messages per subject",
-            &["subject"],
         )
         .expect("metric must be created");
 
-        let message_size_histogram = register_histogram_vec!(
+        let message_size_histogram = register_histogram!(
             format!("{}publisher_metrics_message_size_bytes", metric_prefix),
             "Histogram of message sizes in bytes",
-            &["subject"],
             vec![
                 50.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0, 100000.0,
                 1000000.0
@@ -85,17 +85,14 @@ impl Metrics {
 
     pub fn update_publisher_success_metrics(
         &self,
-        subject: &str,
         published_data_size: usize,
     ) {
         // Update message size histogram
         self.message_size_histogram
-            .with_label_values(&[subject])
             .observe(published_data_size as f64);
 
         // Increment throughput for the published messages
         self.published_messages_throughput
-            .with_label_values(&[subject])
             .inc();
     }
 

--- a/services/publisher/src/metrics.rs
+++ b/services/publisher/src/metrics.rs
@@ -2,11 +2,11 @@ use async_trait::async_trait;
 use fuel_web_utils::telemetry::metrics::TelemetryMetrics;
 use prometheus::{
     register_histogram,
-    register_int_counter_vec,
     register_int_counter,
+    register_int_counter_vec,
     Histogram,
-    IntCounterVec,
     IntCounter,
+    IntCounterVec,
     Registry,
 };
 
@@ -83,17 +83,13 @@ impl Metrics {
         })
     }
 
-    pub fn update_publisher_success_metrics(
-        &self,
-        published_data_size: usize,
-    ) {
+    pub fn update_publisher_success_metrics(&self, published_data_size: usize) {
         // Update message size histogram
         self.message_size_histogram
             .observe(published_data_size as f64);
 
         // Increment throughput for the published messages
-        self.published_messages_throughput
-            .inc();
+        self.published_messages_throughput.inc();
     }
 
     pub fn update_publisher_error_metrics(&self, subject: &str, error: &str) {

--- a/services/publisher/src/publish.rs
+++ b/services/publisher/src/publish.rs
@@ -31,7 +31,6 @@ pub async fn publish_block(
 
     if let Some(metrics) = telemetry.base_metrics() {
         metrics.update_publisher_success_metrics(
-            &subject.to_string(&importer_queue),
             encoded.len(),
         );
     }

--- a/services/publisher/src/publish.rs
+++ b/services/publisher/src/publish.rs
@@ -30,9 +30,7 @@ pub async fn publish_block(
     importer_queue.publish(&subject, encoded.clone()).await?;
 
     if let Some(metrics) = telemetry.base_metrics() {
-        metrics.update_publisher_success_metrics(
-            encoded.len(),
-        );
+        metrics.update_publisher_success_metrics(encoded.len());
     }
 
     tracing::info!(

--- a/services/webserver/src/metrics.rs
+++ b/services/webserver/src/metrics.rs
@@ -124,9 +124,7 @@ impl Metrics {
         })
     }
 
-    pub fn update_user_subscription_metrics(
-        &self,
-    ) {
+    pub fn update_user_subscription_metrics(&self) {
         self.user_subscribed_messages.inc();
 
         // Increment throughput for the subscribed messages
@@ -147,36 +145,23 @@ impl Metrics {
         self.total_ws_subs.dec();
     }
 
-    pub fn update_unsubscribed(
-        &self,
-    ) {
+    pub fn update_unsubscribed(&self) {
         self.user_subscribed_messages.dec();
     }
 
-    pub fn update_subscribed(
-        &self,
-    ) {
+    pub fn update_subscribed(&self) {
         self.user_subscribed_messages.inc();
     }
 
-    pub fn track_connection_duration(
-        &self,
-        duration: Duration,
-    ) {
-        self.connection_duration
-            .observe(duration.as_secs_f64());
+    pub fn track_connection_duration(&self, duration: Duration) {
+        self.connection_duration.observe(duration.as_secs_f64());
     }
 
-    pub fn track_duplicate_subscription(
-        &self,
-    ) {
+    pub fn track_duplicate_subscription(&self) {
         self.duplicate_subscription_attempts.inc();
     }
 
-    pub fn update_user_subscription_count(
-        &self,
-        change: &SubscriptionChange,
-    ) {
+    pub fn update_user_subscription_count(&self, change: &SubscriptionChange) {
         let delta = match change {
             SubscriptionChange::Added => 1,
             SubscriptionChange::Removed => -1,
@@ -204,9 +189,7 @@ mod tests {
     fn test_user_subscribed_messages_metric() {
         let metrics = Metrics::random();
 
-        metrics
-            .user_subscribed_messages
-            .set(5);
+        metrics.user_subscribed_messages.set(5);
 
         let metric_families = gather();
         let mut buffer = Vec::new();
@@ -240,9 +223,7 @@ mod tests {
     fn test_subs_messages_throughput_metric() {
         let metrics = Metrics::random();
 
-        metrics
-            .subs_messages_throughput
-            .inc_by(10);
+        metrics.subs_messages_throughput.inc_by(10);
 
         let metric_families = gather();
         let mut buffer = Vec::new();

--- a/services/webserver/src/metrics.rs
+++ b/services/webserver/src/metrics.rs
@@ -1,15 +1,16 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use fuel_streams_core::server::Subscription;
-use fuel_web_utils::{api_key::ApiKeyId, telemetry::metrics::TelemetryMetrics};
+use fuel_web_utils::telemetry::metrics::TelemetryMetrics;
 use prometheus::{
-    register_histogram_vec,
+    register_histogram,
+    register_int_counter,
     register_int_counter_vec,
-    register_int_gauge_vec,
-    HistogramVec,
+    register_int_gauge,
+    Histogram,
+    IntCounter,
     IntCounterVec,
-    IntGaugeVec,
+    IntGauge,
     Registry,
 };
 
@@ -22,14 +23,12 @@ pub enum SubscriptionChange {
 #[derive(Clone, Debug)]
 pub struct Metrics {
     pub registry: Registry,
-    pub total_ws_subs: IntGaugeVec,
-    pub user_subscribed_messages: IntGaugeVec,
-    pub subs_messages_throughput: IntCounterVec,
+    pub total_ws_subs: IntGauge,
+    pub user_subscribed_messages: IntGauge,
+    pub subs_messages_throughput: IntCounter,
     pub subs_messages_error_rates: IntCounterVec,
-    pub connection_duration: HistogramVec,
-    pub duplicate_subscription_attempts: IntCounterVec,
-    pub user_active_subscriptions: IntGaugeVec,
-    pub subscription_lifetime: HistogramVec,
+    pub connection_duration: Histogram,
+    pub duplicate_subscription_attempts: IntCounter,
 }
 
 impl Default for Metrics {
@@ -60,30 +59,27 @@ impl Metrics {
             .map(|p| format!("{}_", p))
             .unwrap_or_default();
 
-        let total_ws_subs = register_int_gauge_vec!(
+        let total_ws_subs = register_int_gauge!(
             format!("{}ws_streamer_metrics_total_subscriptions", metric_prefix),
             "A metric counting the number of active ws subscriptions",
-            &[],
         )
         .expect("metric must be created");
 
-        let user_subscribed_messages = register_int_gauge_vec!(
+        let user_subscribed_messages = register_int_gauge!(
             format!(
                 "{}ws_streamer_metrics_user_subscribed_messages",
                 metric_prefix
             ),
             "A metric counting the number of published messages",
-            &["user_id", "user_name", "subject"],
         )
         .expect("metric must be created");
 
-        let subs_messages_throughput = register_int_counter_vec!(
+        let subs_messages_throughput = register_int_counter!(
             format!(
                 "{}ws_streamer_metrics_subs_messages_throughput",
                 metric_prefix
             ),
-            "A metric counting the number of subscription messages per subject",
-            &["subject"],
+            "A metric counting the number of subscription messages",
         )
         .expect("metric must be created");
 
@@ -91,37 +87,20 @@ impl Metrics {
             register_int_counter_vec!(
             format!("{}ws_streamer_metrics_subs_messages_error_rates", metric_prefix),
             "A metric counting errors or failures during subscription message processing",
-            &["subject", "error_type"],
+            &["error_type"],
         )
             .expect("metric must be created");
 
-        let connection_duration = register_histogram_vec!(
+        let connection_duration = register_histogram!(
             format!("{}ws_connection_duration_seconds", metric_prefix),
             "Duration of WebSocket connections in seconds",
-            &["user_id", "user_name"],
             vec![0.1, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0, 600.0, 1800.0, 3600.0]
         )
         .expect("metric must be created");
 
-        let duplicate_subscription_attempts = register_int_counter_vec!(
+        let duplicate_subscription_attempts = register_int_counter!(
             format!("{}ws_duplicate_subscription_attempts", metric_prefix),
             "Number of attempts to create duplicate subscriptions",
-            &["user_id", "user_name", "subscription_id"]
-        )
-        .expect("metric must be created");
-
-        let user_active_subscriptions = register_int_gauge_vec!(
-            format!("{}ws_user_active_subscriptions", metric_prefix),
-            "Number of active subscriptions per user",
-            &["user_id", "user_name"]
-        )
-        .expect("metric must be created");
-
-        let subscription_lifetime = register_histogram_vec!(
-            format!("{}ws_subscription_lifetime_seconds", metric_prefix),
-            "Duration of individual subscriptions in seconds",
-            &["user_id", "user_name", "subscription_id"],
-            vec![0.1, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0, 600.0, 1800.0, 3600.0]
         )
         .expect("metric must be created");
 
@@ -133,8 +112,6 @@ impl Metrics {
         registry.register(Box::new(subs_messages_error_rates.clone()))?;
         registry.register(Box::new(connection_duration.clone()))?;
         registry.register(Box::new(duplicate_subscription_attempts.clone()))?;
-        registry.register(Box::new(user_active_subscriptions.clone()))?;
-        registry.register(Box::new(subscription_lifetime.clone()))?;
 
         Ok(Self {
             registry,
@@ -144,29 +121,16 @@ impl Metrics {
             subs_messages_error_rates,
             connection_duration,
             duplicate_subscription_attempts,
-            user_active_subscriptions,
-            subscription_lifetime,
         })
     }
 
     pub fn update_user_subscription_metrics(
         &self,
-        user_id: ApiKeyId,
-        user_name: &str,
-        subject: &str,
     ) {
-        self.user_subscribed_messages
-            .with_label_values(&[
-                user_id.to_string().as_str(),
-                user_name,
-                subject,
-            ])
-            .inc();
+        self.user_subscribed_messages.inc();
 
         // Increment throughput for the subscribed messages
-        self.subs_messages_throughput
-            .with_label_values(&[subject])
-            .inc();
+        self.subs_messages_throughput.inc();
     }
 
     pub fn update_error_metrics(&self, subject: &str, error_type: &str) {
@@ -176,66 +140,41 @@ impl Metrics {
     }
 
     pub fn increment_subscriptions_count(&self) {
-        self.total_ws_subs.with_label_values(&[]).inc();
+        self.total_ws_subs.inc();
     }
 
     pub fn decrement_subscriptions_count(&self) {
-        self.total_ws_subs.with_label_values(&[]).dec();
+        self.total_ws_subs.dec();
     }
 
     pub fn update_unsubscribed(
         &self,
-        user_id: &ApiKeyId,
-        user_name: &str,
-        subject: &str,
     ) {
-        self.user_subscribed_messages
-            .with_label_values(&[&user_id.to_string(), user_name, subject])
-            .dec();
+        self.user_subscribed_messages.dec();
     }
 
     pub fn update_subscribed(
         &self,
-        user_id: &ApiKeyId,
-        user_name: &str,
-        subject: &str,
     ) {
-        self.user_subscribed_messages
-            .with_label_values(&[&user_id.to_string(), user_name, subject])
-            .inc();
+        self.user_subscribed_messages.inc();
     }
 
     pub fn track_connection_duration(
         &self,
-        user_id: &ApiKeyId,
-        user_name: &str,
         duration: Duration,
     ) {
         self.connection_duration
-            .with_label_values(&[&user_id.to_string(), user_name])
             .observe(duration.as_secs_f64());
     }
 
     pub fn track_duplicate_subscription(
         &self,
-        user_id: &ApiKeyId,
-        user_name: &str,
-        subscription_id: &Subscription,
     ) {
-        self.duplicate_subscription_attempts
-            .with_label_values(&[
-                &user_id.to_string(),
-                user_name,
-                &subscription_id.to_string(),
-            ])
-            .inc();
+        self.duplicate_subscription_attempts.inc();
     }
 
     pub fn update_user_subscription_count(
         &self,
-        user_id: &ApiKeyId,
-        user_name: &str,
-        subject: &str,
         change: &SubscriptionChange,
     ) {
         let delta = match change {
@@ -243,31 +182,8 @@ impl Metrics {
             SubscriptionChange::Removed => -1,
         };
 
-        // Update per-user subscription count
-        self.user_active_subscriptions
-            .with_label_values(&[&user_id.to_string(), user_name])
-            .add(delta);
-
         // Update subject-specific count
-        self.user_subscribed_messages
-            .with_label_values(&[&user_id.to_string(), user_name, subject])
-            .add(delta);
-    }
-
-    pub fn track_subscription_lifetime(
-        &self,
-        user_id: &ApiKeyId,
-        user_name: &str,
-        subscription_id: &Subscription,
-        duration: Duration,
-    ) {
-        self.subscription_lifetime
-            .with_label_values(&[
-                &user_id.to_string(),
-                user_name,
-                &subscription_id.to_string(),
-            ])
-            .observe(duration.as_secs_f64());
+        self.user_subscribed_messages.add(delta);
     }
 }
 
@@ -290,7 +206,6 @@ mod tests {
 
         metrics
             .user_subscribed_messages
-            .with_label_values(&["user_id_1", "user_name_1", "subject_1"])
             .set(5);
 
         let metric_families = gather();
@@ -301,9 +216,6 @@ mod tests {
         let output = String::from_utf8(buffer.clone()).unwrap();
 
         assert!(output.contains("ws_streamer_metrics_user_subscribed_messages"));
-        assert!(output.contains("user_id_1"));
-        assert!(output.contains("user_name_1"));
-        assert!(output.contains("subject_1"));
         assert!(output.contains("5"));
     }
 
@@ -311,7 +223,7 @@ mod tests {
     fn test_subs_messages_total_metric() {
         let metrics = Metrics::random();
 
-        metrics.total_ws_subs.with_label_values(&[]).set(10);
+        metrics.total_ws_subs.set(10);
 
         let metric_families = gather();
         let mut buffer = Vec::new();
@@ -330,7 +242,6 @@ mod tests {
 
         metrics
             .subs_messages_throughput
-            .with_label_values(&["subject_1"])
             .inc_by(10);
 
         let metric_families = gather();
@@ -341,7 +252,6 @@ mod tests {
         let output = String::from_utf8(buffer.clone()).unwrap();
 
         assert!(output.contains("ws_streamer_metrics_subs_messages_throughput"));
-        assert!(output.contains("subject_1"));
         assert!(output.contains("10"));
     }
 
@@ -351,7 +261,7 @@ mod tests {
 
         metrics
             .subs_messages_error_rates
-            .with_label_values(&["subject_1", "timeout"])
+            .with_label_values(&["timeout"])
             .inc_by(1);
 
         let metric_families = gather();
@@ -364,7 +274,6 @@ mod tests {
         assert!(
             output.contains("ws_streamer_metrics_subs_messages_error_rates")
         );
-        assert!(output.contains("subject_1"));
         assert!(output.contains("timeout"));
         assert!(output.contains("1"));
     }

--- a/services/webserver/src/server/websocket/session.rs
+++ b/services/webserver/src/server/websocket/session.rs
@@ -78,11 +78,7 @@ impl MetricsHandler {
         Self { telemetry }
     }
 
-    fn track_subscription(
-        &self,
-        subscription: &Subscription,
-        change: SubscriptionChange,
-    ) {
+    fn track_subscription(&self, change: SubscriptionChange) {
         if let Some(metrics) = self.telemetry.base_metrics() {
             metrics.update_user_subscription_count(&change);
             match change {
@@ -152,7 +148,7 @@ impl SubscriptionManager {
         self.active_subscriptions.insert(subscription.clone(), ());
         self.rate_limiter.add_active_key_sub(api_key.id());
         self.metrics_handler
-            .track_subscription(subscription, SubscriptionChange::Added);
+            .track_subscription(SubscriptionChange::Added);
 
         let api_key_id = api_key.id();
         let api_key_role = api_key.role();
@@ -167,15 +163,15 @@ impl SubscriptionManager {
         self.shutdown().await;
         if self.active_subscriptions.remove(subscription).is_some() {
             self.metrics_handler
-                .track_subscription(subscription, SubscriptionChange::Removed);
+                .track_subscription(SubscriptionChange::Removed);
         }
         self.rate_limiter.remove_active_key_sub(self.api_key.id());
     }
 
     pub async fn clear_subscriptions(&self) {
-        for entry in self.active_subscriptions.iter() {
+        for _entry in self.active_subscriptions.iter() {
             self.metrics_handler
-                .track_subscription(entry.key(), SubscriptionChange::Removed);
+                .track_subscription(SubscriptionChange::Removed);
         }
         self.active_subscriptions.clear();
         self.rate_limiter.remove_active_key_sub(self.api_key.id());

--- a/services/webserver/src/server/websocket/session.rs
+++ b/services/webserver/src/server/websocket/session.rs
@@ -90,9 +90,6 @@ impl MetricsHandler {
         if let Some(metrics) = self.telemetry.base_metrics() {
             let subject = subscription.payload.subject.clone();
             metrics.update_user_subscription_count(
-                self.api_key.id(),
-                self.api_key.user(),
-                &subject,
                 &change,
             );
             match change {
@@ -109,8 +106,6 @@ impl MetricsHandler {
     fn track_connection_duration(&self, duration: Duration) {
         if let Some(metrics) = self.telemetry.base_metrics() {
             metrics.track_connection_duration(
-                self.api_key.id(),
-                self.api_key.user(),
                 duration,
             );
         }

--- a/services/webserver/src/server/websocket/session.rs
+++ b/services/webserver/src/server/websocket/session.rs
@@ -89,9 +89,7 @@ impl MetricsHandler {
     ) {
         if let Some(metrics) = self.telemetry.base_metrics() {
             let subject = subscription.payload.subject.clone();
-            metrics.update_user_subscription_count(
-                &change,
-            );
+            metrics.update_user_subscription_count(&change);
             match change {
                 SubscriptionChange::Added => {
                     metrics.increment_subscriptions_count()
@@ -105,9 +103,7 @@ impl MetricsHandler {
 
     fn track_connection_duration(&self, duration: Duration) {
         if let Some(metrics) = self.telemetry.base_metrics() {
-            metrics.track_connection_duration(
-                duration,
-            );
+            metrics.track_connection_duration(duration);
         }
     }
 }

--- a/services/webserver/src/server/websocket/session.rs
+++ b/services/webserver/src/server/websocket/session.rs
@@ -71,15 +71,11 @@ impl MessageHandler {
 #[derive(Clone)]
 struct MetricsHandler {
     telemetry: Arc<Telemetry<Metrics>>,
-    api_key: ApiKey,
 }
 
 impl MetricsHandler {
-    fn new(telemetry: Arc<Telemetry<Metrics>>, api_key: &ApiKey) -> Self {
-        Self {
-            telemetry,
-            api_key: api_key.to_owned(),
-        }
+    fn new(telemetry: Arc<Telemetry<Metrics>>) -> Self {
+        Self { telemetry }
     }
 
     fn track_subscription(
@@ -88,7 +84,6 @@ impl MetricsHandler {
         change: SubscriptionChange,
     ) {
         if let Some(metrics) = self.telemetry.base_metrics() {
-            let subject = subscription.payload.subject.clone();
             metrics.update_user_subscription_count(&change);
             match change {
                 SubscriptionChange::Added => {
@@ -209,7 +204,7 @@ impl WsSession {
         rate_limiter: Arc<RateLimitsController>,
         socket: WebSocket,
     ) -> Self {
-        let metrics = MetricsHandler::new(telemetry, api_key);
+        let metrics = MetricsHandler::new(telemetry);
         let connection =
             SubscriptionManager::new(api_key, metrics, rate_limiter);
         let messaging = MessageHandler::new(api_key);


### PR DESCRIPTION
Reducing the cardinality of prometheus metrics down to a usable level. Currently, cardinality on metrics includes the block ID and user IDs, which means we have an exponential explosion of metrics inside monitoring systems.

This means that it is _very_ expensive to collect and report on metrics from this service.