### PR TITLE
feat(sv-publisher): Add routine to sync historical gaps

### DIFF
--- a/services/publisher/src/lib.rs
+++ b/services/publisher/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cli;
 pub mod error;
 pub mod gaps;
+pub mod history;
 pub mod metrics;
 pub mod publish;
 pub mod recover;

--- a/services/publisher/src/main.rs
+++ b/services/publisher/src/main.rs
@@ -12,6 +12,7 @@ use fuel_web_utils::{
 use sv_publisher::{
     cli::Cli,
     error::PublishError,
+    history::process_historical_gaps,
     metrics::Metrics,
     publish::publish_block,
     recover::recover_tx_pointers,
@@ -41,11 +42,22 @@ async fn main() -> anyhow::Result<()> {
     let server_state =
         ServerState::new(message_broker.clone(), Arc::clone(&telemetry));
     let server = ServerBuilder::build(&server_state, cli.telemetry_port);
+    let historical_gaps = process_historical_gaps(
+        cli.from_block.into(),
+        &db,
+        &message_broker,
+        &fuel_core,
+        &last_block_height,
+        &shutdown,
+        &telemetry,
+    )
+    .await?;
 
     tokio::select! {
         result = async {
             tokio::join!(
                 recover_tx_pointers(&db),
+                historical_gaps,
                 process_live_blocks(
                     &message_broker,
                     &fuel_core,


### PR DESCRIPTION
This pull request introduces periodic processing of historical gaps in block publishing and refactors the block processing logic to improve efficiency and clarity. Additionally, it integrates the new functionality into the main application workflow and updates module exports.

### New functionality for periodic processing:

* [`services/publisher/src/history.rs`](diffhunk://#diff-15afc710ffdc91810773a93ad8ee2802998dbcd10923a1230fdbf52dd756376dR17-R54): Added the `process_historical_gaps_periodically` function to periodically process historical gaps every 5 hours, ensuring shutdown signals are handled gracefully.

### Refactoring for efficiency:

* [`services/publisher/src/history.rs`](diffhunk://#diff-15afc710ffdc91810773a93ad8ee2802998dbcd10923a1230fdbf52dd756376dL74-R113): Replaced `process_blocks_with_join_set` with `process_blocks`, removing the use of `JoinSet` and `Semaphore`. The new implementation processes blocks in chunks of 50 for improved scalability and clarity, while handling errors and shutdown signals more effectively. [[1]](diffhunk://#diff-15afc710ffdc91810773a93ad8ee2802998dbcd10923a1230fdbf52dd756376dL74-R113) [[2]](diffhunk://#diff-15afc710ffdc91810773a93ad8ee2802998dbcd10923a1230fdbf52dd756376dL87-R194)

### Integration into main application workflow:

* [`services/publisher/src/main.rs`](diffhunk://#diff-9f7cee1f2f1db0ee7ee43f9ed558552bf7e74aa2ddf680313d495329e61d6bcfR50-R58): Integrated the `process_historical_gaps_periodically` function into the main application workflow, ensuring historical gaps are processed alongside live blocks and transaction pointer recovery.

### Module export updates:

* [`services/publisher/src/lib.rs`](diffhunk://#diff-e649a3437a1188fc09dca53ddeb5fed82ef7688497e4707aea26fac8ddfcbc35R4): Added the `history` module to the list of exports to make the new functionality accessible across the application.

### Dependency updates:

* [`services/publisher/src/history.rs`](diffhunk://#diff-15afc710ffdc91810773a93ad8ee2802998dbcd10923a1230fdbf52dd756376dL7-R7): Updated imports to include `tokio::time::{interval, Duration}` for scheduling periodic tasks.