### PR TITLE
feat(sv-publisher): Add historical interval configuration

### DIFF
--- a/services/publisher/src/cli.rs
+++ b/services/publisher/src/cli.rs
@@ -55,4 +55,13 @@ pub struct Cli {
         help = "Enable metrics"
     )]
     pub use_metrics: bool,
+    /// Historical gap processing interval in seconds
+    #[arg(
+        long,
+        value_name = "HISTORY_INTERVAL",
+        env = "HISTORY_INTERVAL",
+        default_value = "259200",
+        help = "Interval in seconds for processing historical gaps (default: 3 days). Set to 0 to disable."
+    )]
+    pub history_interval: u64,
 }

--- a/services/publisher/src/main.rs
+++ b/services/publisher/src/main.rs
@@ -48,6 +48,7 @@ async fn main() -> anyhow::Result<()> {
             tokio::join!(
                 recover_tx_pointers(&db),
                 process_historical_gaps_periodically(
+                    cli.history_interval,
                     cli.from_block.into(),
                     &db,
                     &message_broker,

--- a/services/publisher/src/recover.rs
+++ b/services/publisher/src/recover.rs
@@ -25,7 +25,7 @@ async fn fetch_transaction_chunk(
     pool: &PgPool,
     offset: i64,
 ) -> Result<Vec<TransactionRecord>> {
-    println!("Fetching transaction chunk with offset {}", offset);
+    tracing::info!("Fetching transaction chunk with offset {}", offset);
     sqlx::query_as::<_, TransactionRecord>(
         "SELECT id, block_height, tx_index
          FROM transactions
@@ -106,7 +106,7 @@ pub async fn recover_tx_pointers(db: &Arc<Db>) -> Result<()> {
         total_updated += result??;
     }
 
-    println!(
+    tracing::info!(
         "Successfully completed transaction updates. Total transactions updated: {}",
         total_updated
     );


### PR DESCRIPTION
This pull request introduces a new configuration option for historical gap processing intervals, refactors logging to use structured tracing, and enhances the flexibility of periodic tasks. The most important changes include adding the `history_interval` parameter to the CLI, enabling dynamic control of historical gap processing intervals, and replacing `println!` statements with `tracing::info!` for improved logging.

### Configuration Enhancements:
* [`services/publisher/src/cli.rs`](diffhunk://#diff-f23190d588bcdc6d5310ff04b44a044028217d9cca9eb2b7309f5941a7bed79bR58-R66): Added a new CLI argument `history_interval` to configure the interval for processing historical gaps. The default value is set to 259200 seconds (3 days), with an option to disable by setting it to 0.

### Periodic Task Improvements:
* [`services/publisher/src/history.rs`](diffhunk://#diff-15afc710ffdc91810773a93ad8ee2802998dbcd10923a1230fdbf52dd756376dL26-R34): Updated `process_historical_gaps_periodically` to dynamically adjust the interval based on the new `history_interval` parameter. If the interval is set to 0, the task is disabled and logs a message indicating this.
* [`services/publisher/src/main.rs`](diffhunk://#diff-9f7cee1f2f1db0ee7ee43f9ed558552bf7e74aa2ddf680313d495329e61d6bcfR51): Modified the `process_historical_gaps_periodically` invocation in `main` to use the `history_interval` parameter from the CLI.

### Logging Refactor:
* [`services/publisher/src/recover.rs`](diffhunk://#diff-6b6e0353ac70334279a11ba6788f8d69296cd255554cc1e2d904ebdb6a3bc1c6L28-R28): Replaced `println!` statements with `tracing::info!` for structured and consistent logging in `fetch_transaction_chunk` and `recover_tx_pointers`. [[1]](diffhunk://#diff-6b6e0353ac70334279a11ba6788f8d69296cd255554cc1e2d904ebdb6a3bc1c6L28-R28) [[2]](diffhunk://#diff-6b6e0353ac70334279a11ba6788f8d69296cd255554cc1e2d904ebdb6a3bc1c6L109-R109)