### PR TITLE
feat(sv-api): Add read-only database configuration

### DIFF
--- a/crates/domains/src/infra/db/db_impl.rs
+++ b/crates/domains/src/infra/db/db_impl.rs
@@ -60,6 +60,7 @@ pub static DB_ACQUIRE_TIMEOUT: LazyLock<usize> = LazyLock::new(|| {
 pub struct DbConnectionOpts {
     pub connection_str: String,
     pub pool_size: Option<u32>,
+    pub min_connections: Option<u32>,
     pub statement_timeout: Option<Duration>,
     pub acquire_timeout: Option<Duration>,
     pub idle_timeout: Option<Duration>,
@@ -69,6 +70,7 @@ impl Default for DbConnectionOpts {
     fn default() -> Self {
         Self {
             pool_size: Some(*DB_POOL_SIZE as u32),
+            min_connections: Some(2),
             connection_str: dotenvy::var("DATABASE_URL")
                 .expect("DATABASE_URL not set"),
             statement_timeout: Some(Duration::from_secs(240)),
@@ -105,7 +107,7 @@ impl Db {
                 .options(Self::connect_opts(opts));
 
         sqlx::postgres::PgPoolOptions::new()
-            .min_connections(2)
+            .min_connections(opts.min_connections.unwrap_or_default())
             .max_connections(opts.pool_size.unwrap_or_default())
             .acquire_timeout(opts.acquire_timeout.unwrap_or_default())
             .idle_timeout(opts.idle_timeout)

--- a/services/api/src/cli.rs
+++ b/services/api/src/cli.rs
@@ -23,6 +23,15 @@ pub struct Cli {
     )]
     pub db_url: String,
 
+    /// Database URL to connect to.
+    #[arg(
+        long,
+        value_name = "DATABASE_URL_READ",
+        env = "DATABASE_URL_READ",
+        help = "ReadOnly Database URL to connect to, if not provided use the same as DATABASE_URL"
+    )]
+    pub db_url_read: Option<String>,
+
     /// Use metrics
     #[arg(
         long,

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -30,6 +30,7 @@ pub struct ApiConfig {
 #[derive(Clone, Debug)]
 pub struct DbConfig {
     pub url: String,
+    pub read_url: String,
 }
 
 #[derive(Clone, Debug)]
@@ -52,6 +53,7 @@ impl Config {
             },
             db: DbConfig {
                 url: cli.db_url.clone(),
+                read_url: cli.db_url_read.clone().unwrap_or(cli.db_url.clone()),
             },
         })
     }

--- a/services/api/src/server/handlers/api_key.rs
+++ b/services/api/src/server/handlers/api_key.rs
@@ -66,7 +66,8 @@ pub async fn generate_api_key(
 ) -> Result<Json<ApiKey>, Error> {
     req.validate().map_err(Error::Validation)?;
     let api_key =
-        ApiKey::create(state.db.pool_ref(), &req.username, &req.role).await?;
+        ApiKey::create(state.db_write.pool_ref(), &req.username, &req.role)
+            .await?;
     Ok(Json(api_key))
 }
 

--- a/services/publisher/src/cli.rs
+++ b/services/publisher/src/cli.rs
@@ -39,6 +39,14 @@ pub struct Cli {
         help = "Database URL to connect to."
     )]
     pub db_url: String,
+    /// Database URL to connect to.
+    #[arg(
+        long,
+        value_name = "DATABASE_URL_READ",
+        env = "DATABASE_URL_READ",
+        help = "ReadOnly Database URL to connect to, if not provided use the same as DATABASE_URL."
+    )]
+    pub db_url_read: Option<String>,
     /// Start from block height
     #[arg(
         long,
@@ -60,8 +68,8 @@ pub struct Cli {
         long,
         value_name = "HISTORY_INTERVAL",
         env = "HISTORY_INTERVAL",
-        default_value = "259200",
-        help = "Interval in seconds for processing historical gaps (default: 3 days). Set to 0 to disable."
+        default_value = "0",
+        help = "Interval in seconds for processing historical gaps (default: 0 - disabled)."
     )]
     pub history_interval: u64,
 }


### PR DESCRIPTION
This pull request introduces support for separate read and write database connections across multiple services, along with some additional configuration improvements. The changes include adding a `read_url` for databases, updating connection pool configurations, and modifying service logic to utilize the new read and write database separation.

### Database Connection Enhancements:
* Added a `min_connections` field to `DbConnectionOpts` and updated the default implementation to set a minimum of 2 connections. Updated `PgPoolOptions` to use `min_connections` from the configuration instead of a hardcoded value. (`crates/domains/src/infra/db/db_impl.rs`) [[1]](diffhunk://#diff-4516faa69b5cbfef33757b1ea643ec75c80cad97faf053161a098c4cffeb1b51R63) [[2]](diffhunk://#diff-4516faa69b5cbfef33757b1ea643ec75c80cad97faf053161a098c4cffeb1b51R73) [[3]](diffhunk://#diff-4516faa69b5cbfef33757b1ea643ec75c80cad97faf053161a098c4cffeb1b51L108-R110)
* Added support for a `read_url` in the `DbConfig` struct and CLI options for both `api` and `publisher` services. If `read_url` is not provided, it defaults to the main `db_url`. (`services/api/src/cli.rs`, `services/api/src/config.rs`, `services/publisher/src/cli.rs`) [[1]](diffhunk://#diff-7308f7e6c3e8ecf034e838fde2a273c635c1e4aadca4f00c1afe23c8b05b084cR26-R34) [[2]](diffhunk://#diff-85596d74e21c85a435cb5111e325a7a68f0ad038e210b19b8240f014ec95934fR33) [[3]](diffhunk://#diff-85596d74e21c85a435cb5111e325a7a68f0ad038e210b19b8240f014ec95934fR56) [[4]](diffhunk://#diff-f23190d588bcdc6d5310ff04b44a044028217d9cca9eb2b7309f5941a7bed79bR42-R49)

### Service Logic Updates:
* Updated the `ServerState` struct in the `api` service to include separate `db` (read) and `db_write` (write) connections. Adjusted the initialization logic and database-related operations to use the appropriate connection. (`services/api/src/server/state.rs`, `services/api/src/server/handlers/api_key.rs`) [[1]](diffhunk://#diff-afcf63feddbf45ee8c8ba9123ce624e0d0073d8c49c52b0ccfebc8a09d080bd7R21-R40) [[2]](diffhunk://#diff-afcf63feddbf45ee8c8ba9123ce624e0d0073d8c49c52b0ccfebc8a09d080bd7R51) [[3]](diffhunk://#diff-b2b6b0b6046fd7be4049ecfbfca0b73bd5cd274b86cfea55d5fd99a6638ed96eL69-R70)
* Refactored the `publisher` service to use a `DbState` struct containing separate `read` and `write` database connections. Updated database operations to use the correct connection based on the operation type. (`services/publisher/src/main.rs`) [[1]](diffhunk://#diff-9f7cee1f2f1db0ee7ee43f9ed558552bf7e74aa2ddf680313d495329e61d6bcfR23-R35) [[2]](diffhunk://#diff-9f7cee1f2f1db0ee7ee43f9ed558552bf7e74aa2ddf680313d495329e61d6bcfL49-R58) [[3]](diffhunk://#diff-9f7cee1f2f1db0ee7ee43f9ed558552bf7e74aa2ddf680313d495329e61d6bcfL84-R108)

### Configuration Improvements:
* Changed the default value of the `history_interval` in the `publisher` service to `0` (disabled) instead of `259200` (3 days). (`services/publisher/src/cli.rs`)