### PR TITLE
feat(sv-consumer): Add optional db pool size configuration

### DIFF
--- a/services/consumer/src/cli.rs
+++ b/services/consumer/src/cli.rs
@@ -42,7 +42,9 @@ pub struct Cli {
         long,
         env = "CONCURRENT_TASKS",
         default_value = "300",
-        help = "Number of concurrent tasks, this is the number of total blocks processed in parallel, this will also be reflected in the number of connections to the database"
+        help = "Number of concurrent tasks, this is the number of total blocks processed in parallel."
     )]
     pub concurrent_tasks: usize,
+    #[arg(long, env = "DB_POOL_SIZE", help = "Database connection pool size")]
+    pub db_pool_size: Option<usize>,
 }

--- a/services/consumer/src/main.rs
+++ b/services/consumer/src/main.rs
@@ -30,7 +30,8 @@ async fn main() -> anyhow::Result<()> {
     let shutdown = Arc::new(ShutdownController::new());
     shutdown.clone().spawn_signal_handler();
     // Initialize shared resources
-    let db = setup_db(&cli.db_url, cli.concurrent_tasks as u32).await?;
+    let db_pool_size = cli.db_pool_size.unwrap_or(cli.concurrent_tasks);
+    let db = setup_db(&cli.db_url, db_pool_size as u32).await?;
     // 2 minutes before returning to the message broker
     let opts = fuel_message_broker::NatsOpts::new(cli.nats_url.clone())
         .with_ack_wait(120);


### PR DESCRIPTION
This pull request introduces a new configuration option for managing the database connection pool size and updates the related logic in the application. The changes improve flexibility by allowing users to specify the pool size independently of the number of concurrent tasks.

### Configuration Updates:
* [`services/consumer/src/cli.rs`](diffhunk://#diff-8ec3bd62bf8edfb8eba75456a96134626e101323e7f943cb69ac5a706dfd9ec4L45-R49): Added a new `db_pool_size` argument to the CLI, allowing users to specify the database connection pool size via a command-line argument or environment variable. The help text for `concurrent_tasks` was also updated for clarity.

### Database Initialization Logic:
* [`services/consumer/src/main.rs`](diffhunk://#diff-685c4a9ee12ee6a0b4e990d5ca10180359483e54c72ee6f0508f7c8a5719171dL33-R34): Updated the database setup logic to use the new `db_pool_size` argument. If `db_pool_size` is not provided, it defaults to the value of `concurrent_tasks`.