### PR TITLE
add openssl dev library for cross compilation

### DIFF
--- a/cluster/docker/sv-dune.Dockerfile
+++ b/cluster/docker/sv-dune.Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     clang \
     libclang-dev \
     && xx-apt-get update  \
-    && xx-apt-get install -y libc6-dev g++ binutils \
+    && xx-apt-get install -y libc6-dev g++ binutils libssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
`  #37 566.5   cargo:warning=Could not find directory of OpenSSL installation, and this `-sys` crate cannot proceed without this knowledge.`